### PR TITLE
Adiciona adaptador para artigos do Article Meta para o exportador

### DIFF
--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -34,45 +34,45 @@ class DOAJDocument(interfaces.ExporterInterface):
         return self._data["bibjson"]["title"]
 
     def add_bibjson_author(self, article: scielodocument.Article):
-        if not article.data.authors:
+        if not article.authors:
             raise DOAJDocumentNoAuthorsException()
 
         self._data["bibjson"].setdefault("author", [])
-        for author in article.data.authors:
+        for author in article.authors:
             author_name = [author.get('given_names', ''), author.get('surname', '')]
             self._data["bibjson"]["author"].append({"name": author_name})
 
     def add_bibjson_identifier(self, article: scielodocument.Article):
-        issn = article.data.journal.any_issn()
+        issn = article.journal.any_issn()
         if not issn:
             raise DOAJDocumentNoISSNException()
 
-        if issn == article.data.journal.electronic_issn:
+        if issn == article.journal.electronic_issn:
             issn_type = "eissn"
         else:
             issn_type = "pissn"
 
         self._data["bibjson"]["identifier"] = [{"id": issn, "type": issn_type}]
 
-        if article.data.doi:
+        if article.doi:
             self._data["bibjson"]["identifier"].append(
-                {"id": article.data.doi, "type": "doi"}
+                {"id": article.doi, "type": "doi"}
             )
 
     def add_bibjson_title(self, article: scielodocument.Article):
-        title = article.data.original_title()
+        title = article.original_title()
         if (
             not title and
-            article.data.translated_titles() and
-            len(article.data.translated_titles()) != 0
+            article.translated_titles() and
+            len(article.translated_titles()) != 0
         ):
-            item = [(k, v) for k, v in article.data.translated_titles().items()][0]
+            item = [(k, v) for k, v in article.translated_titles().items()][0]
             title = item[1]
 
         if not title:
-            section_code = article.data.section_code
-            original_lang = article.data.original_language()
-            title = article.data.issue.sections.get(section_code, {}).get(
+            section_code = article.section_code
+            original_lang = article.original_language()
+            title = article.issue.sections.get(section_code, {}).get(
                 original_lang, "Documento sem título"
             )
 

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -15,32 +15,32 @@ class DOAJDocumentNoISSNException(Exception):
 
 class DOAJDocument(interfaces.ExporterInterface):
     def __init__(self, article: scielodocument.Article):
-        self.data = {}
-        self.data.setdefault("bibjson", {})
+        self._data = {}
+        self._data.setdefault("bibjson", {})
         self.add_bibjson_author(article)
         self.add_bibjson_identifier(article)
         self.add_bibjson_title(article)
 
     @property
     def bibjson_author(self) -> typing.List[dict]:
-        return self.data["bibjson"]["author"]
+        return self._data["bibjson"]["author"]
 
     @property
     def bibjson_identifier(self) -> typing.List[dict]:
-        return self.data["bibjson"]["identifier"]
+        return self._data["bibjson"]["identifier"]
 
     @property
     def bibjson_title(self) -> str:
-        return self.data["bibjson"]["title"]
+        return self._data["bibjson"]["title"]
 
     def add_bibjson_author(self, article: scielodocument.Article):
         if not article.data.authors:
             raise DOAJDocumentNoAuthorsException()
 
-        self.data["bibjson"].setdefault("author", [])
+        self._data["bibjson"].setdefault("author", [])
         for author in article.data.authors:
             author_name = [author.get('given_names', ''), author.get('surname', '')]
-            self.data["bibjson"]["author"].append({"name": author_name})
+            self._data["bibjson"]["author"].append({"name": author_name})
 
     def add_bibjson_identifier(self, article: scielodocument.Article):
         issn = article.data.journal.any_issn()
@@ -52,10 +52,10 @@ class DOAJDocument(interfaces.ExporterInterface):
         else:
             issn_type = "pissn"
 
-        self.data["bibjson"]["identifier"] = [{"id": issn, "type": issn_type}]
+        self._data["bibjson"]["identifier"] = [{"id": issn, "type": issn_type}]
 
         if article.data.doi:
-            self.data["bibjson"]["identifier"].append(
+            self._data["bibjson"]["identifier"].append(
                 {"id": article.data.doi, "type": "doi"}
             )
 
@@ -76,7 +76,7 @@ class DOAJDocument(interfaces.ExporterInterface):
                 original_lang, "Documento sem título"
             )
 
-        self.data["bibjson"]["title"] = title
+        self._data["bibjson"]["title"] = title
 
     def get_request(self):
-        return {}
+        return self._data

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -19,6 +19,7 @@ class DOAJDocument(interfaces.ExporterInterface):
         self.data.setdefault("bibjson", {})
         self.add_bibjson_author(article)
         self.add_bibjson_identifier(article)
+        self.add_bibjson_title(article)
 
     @property
     def bibjson_author(self) -> typing.List[dict]:
@@ -27,6 +28,10 @@ class DOAJDocument(interfaces.ExporterInterface):
     @property
     def bibjson_identifier(self) -> typing.List[dict]:
         return self.data["bibjson"]["identifier"]
+
+    @property
+    def bibjson_title(self) -> str:
+        return self.data["bibjson"]["title"]
 
     def add_bibjson_author(self, article: scielodocument.Article):
         if not article.data.authors:
@@ -53,6 +58,25 @@ class DOAJDocument(interfaces.ExporterInterface):
             self.data["bibjson"]["identifier"].append(
                 {"id": article.data.doi, "type": "doi"}
             )
+
+    def add_bibjson_title(self, article: scielodocument.Article):
+        title = article.data.original_title()
+        if (
+            not title and
+            article.data.translated_titles() and
+            len(article.data.translated_titles()) != 0
+        ):
+            item = [(k, v) for k, v in article.data.translated_titles().items()][0]
+            title = item[1]
+
+        if not title:
+            section_code = article.data.section_code
+            original_lang = article.data.original_language()
+            title = article.data.issue.sections.get(section_code, {}).get(
+                original_lang, "Documento sem título"
+            )
+
+        self.data["bibjson"]["title"] = title
 
     def get_request(self):
         return {}

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -5,15 +5,15 @@ from xylose import scielodocument
 from exporter import interfaces
 
 
-class DOAJExporterNoAuthorsException(Exception):
+class DOAJExporterXyloseArticleNoAuthorsException(Exception):
     pass
 
 
-class DOAJExporterNoISSNException(Exception):
+class DOAJExporterXyloseArticleNoISSNException(Exception):
     pass
 
 
-class DOAJExporter(interfaces.IndexExporterInterface):
+class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
     def __init__(self, article: scielodocument.Article):
         self._data = {}
         self._data.setdefault("bibjson", {})
@@ -35,7 +35,7 @@ class DOAJExporter(interfaces.IndexExporterInterface):
 
     def add_bibjson_author(self, article: scielodocument.Article):
         if not article.authors:
-            raise DOAJExporterNoAuthorsException()
+            raise DOAJExporterXyloseArticleNoAuthorsException()
 
         self._data["bibjson"].setdefault("author", [])
         for author in article.authors:
@@ -45,7 +45,7 @@ class DOAJExporter(interfaces.IndexExporterInterface):
     def add_bibjson_identifier(self, article: scielodocument.Article):
         issn = article.journal.any_issn()
         if not issn:
-            raise DOAJExporterNoISSNException()
+            raise DOAJExporterXyloseArticleNoISSNException()
 
         if issn == article.journal.electronic_issn:
             issn_type = "eissn"

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -5,15 +5,15 @@ from xylose import scielodocument
 from exporter import interfaces
 
 
-class DOAJDocumentNoAuthorsException(Exception):
+class DOAJExporterNoAuthorsException(Exception):
     pass
 
 
-class DOAJDocumentNoISSNException(Exception):
+class DOAJExporterNoISSNException(Exception):
     pass
 
 
-class DOAJDocument(interfaces.ExporterInterface):
+class DOAJExporter(interfaces.IndexExporterInterface):
     def __init__(self, article: scielodocument.Article):
         self._data = {}
         self._data.setdefault("bibjson", {})
@@ -35,7 +35,7 @@ class DOAJDocument(interfaces.ExporterInterface):
 
     def add_bibjson_author(self, article: scielodocument.Article):
         if not article.authors:
-            raise DOAJDocumentNoAuthorsException()
+            raise DOAJExporterNoAuthorsException()
 
         self._data["bibjson"].setdefault("author", [])
         for author in article.authors:
@@ -45,7 +45,7 @@ class DOAJDocument(interfaces.ExporterInterface):
     def add_bibjson_identifier(self, article: scielodocument.Article):
         issn = article.journal.any_issn()
         if not issn:
-            raise DOAJDocumentNoISSNException()
+            raise DOAJExporterNoISSNException()
 
         if issn == article.journal.electronic_issn:
             issn_type = "eissn"
@@ -78,5 +78,6 @@ class DOAJDocument(interfaces.ExporterInterface):
 
         self._data["bibjson"]["title"] = title
 
-    def get_request(self):
-        return self._data
+    def export(self):
+        # Send request
+        pass

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -9,15 +9,24 @@ class DOAJDocumentNoAuthorsException(Exception):
     pass
 
 
+class DOAJDocumentNoISSNException(Exception):
+    pass
+
+
 class DOAJDocument(interfaces.ExporterInterface):
     def __init__(self, article: scielodocument.Article):
         self.data = {}
         self.data.setdefault("bibjson", {})
         self.add_bibjson_author(article)
+        self.add_bibjson_identifier(article)
 
     @property
     def bibjson_author(self) -> typing.List[dict]:
         return self.data["bibjson"]["author"]
+
+    @property
+    def bibjson_identifier(self) -> typing.List[dict]:
+        return self.data["bibjson"]["identifier"]
 
     def add_bibjson_author(self, article: scielodocument.Article):
         if not article.data.authors:
@@ -27,6 +36,23 @@ class DOAJDocument(interfaces.ExporterInterface):
         for author in article.data.authors:
             author_name = [author.get('given_names', ''), author.get('surname', '')]
             self.data["bibjson"]["author"].append({"name": author_name})
+
+    def add_bibjson_identifier(self, article: scielodocument.Article):
+        issn = article.data.journal.any_issn()
+        if not issn:
+            raise DOAJDocumentNoISSNException()
+
+        if issn == article.data.journal.electronic_issn:
+            issn_type = "eissn"
+        else:
+            issn_type = "pissn"
+
+        self.data["bibjson"]["identifier"] = [{"id": issn, "type": issn_type}]
+
+        if article.data.doi:
+            self.data["bibjson"]["identifier"].append(
+                {"id": article.data.doi, "type": "doi"}
+            )
 
     def get_request(self):
         return {}

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -1,0 +1,32 @@
+import typing
+
+from xylose import scielodocument
+
+from exporter import interfaces
+
+
+class DOAJDocumentNoAuthorsException(Exception):
+    pass
+
+
+class DOAJDocument(interfaces.ExporterInterface):
+    def __init__(self, article: scielodocument.Article):
+        self.data = {}
+        self.data.setdefault("bibjson", {})
+        self.add_bibjson_author(article)
+
+    @property
+    def bibjson_author(self) -> typing.List[dict]:
+        return self.data["bibjson"]["author"]
+
+    def add_bibjson_author(self, article: scielodocument.Article):
+        if not article.data.authors:
+            raise DOAJDocumentNoAuthorsException()
+
+        self.data["bibjson"].setdefault("author", [])
+        for author in article.data.authors:
+            author_name = [author.get('given_names', ''), author.get('surname', '')]
+            self.data["bibjson"]["author"].append({"name": author_name})
+
+    def get_request(self):
+        return {}

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -1,0 +1,13 @@
+from abc import ABC, abstractmethod
+
+
+class ExporterInterface(ABC):
+    @abstractmethod
+    def get_request(self):
+        pass
+
+
+class IndexExporterInterface(ABC):
+    @abstractmethod
+    def export(self):
+        pass

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -1,12 +1,6 @@
 from abc import ABC, abstractmethod
 
 
-class ExporterInterface(ABC):
-    @abstractmethod
-    def get_request(self):
-        pass
-
-
 class IndexExporterInterface(ABC):
     @abstractmethod
     def export(self):

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -100,6 +100,7 @@ class JobExecutor:
 
 def export_document(
     get_document: callable,
+    index: str,
     collection: str,
     pid: str,
     poison_pill: PoisonPill = PoisonPill(),
@@ -113,7 +114,11 @@ def export_document(
 
 
 def extract_and_export_documents(
-    collection:str, pids:typing.List[str], connection:str=None, domain:str=None
+    index:str,
+    collection:str,
+    pids:typing.List[str],
+    connection:str=None,
+    domain:str=None,
 ) -> None:
     params = {}
     if connection:
@@ -124,7 +129,7 @@ def extract_and_export_documents(
     am_client = AMClient(**params) if params else AMClient()
 
     jobs = [
-        {"get_document": am_client.document, "collection": collection, "pid": pid}
+        {"get_document": am_client.document, "index": index, "collection": collection, "pid": pid}
         for pid in pids
     ]
 
@@ -184,7 +189,7 @@ def main_exporter(sargs):
     logger = logging.getLogger()
     logger.setLevel(level)
 
-    params = {"collection": args.collection}
+    params = {"index": args.index, "collection": args.collection}
     if args.pid:
         params["pids"] = [args.pid]
     elif args.pids:

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -39,12 +39,12 @@ class AMClient:
         return self._client.document(collection=collection, code=pid)
 
 
-class ArticleExporterAdapter(interfaces.IndexExporterInterface):
+class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
     index_exporter: interfaces.IndexExporterInterface
 
     def __init__(self, index: str, article: scielodocument.Article):
         if index == "doaj":
-            self.index_exporter = doaj.DOAJExporter(article)
+            self.index_exporter = doaj.DOAJExporterXyloseArticle(article)
         else:
             raise InvalidIndexExporter()
 
@@ -112,7 +112,7 @@ def export_document(
     if not document or not document.data:
         raise ArticleMetaDocumentNotFound()
 
-    article_adapter = ArticleExporterAdapter(index, document)
+    article_adapter = XyloseArticleExporterAdapter(index, document)
     article_adapter.export()
 
 

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -44,12 +44,12 @@ class ArticleExporterAdapter(interfaces.IndexExporterInterface):
 
     def __init__(self, index: str, article: scielodocument.Article):
         if index == "doaj":
-            self.index_exporter = doaj.DOAJDocument(article)
+            self.index_exporter = doaj.DOAJExporter(article)
         else:
             raise InvalidIndexExporter()
 
     def export(self):
-        request = self.index_exporter.get_request()
+        request = self.index_exporter.export()
 
 
 class PoisonPill:

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -112,6 +112,9 @@ def export_document(
     if not document or not document.data:
         raise ArticleMetaDocumentNotFound()
 
+    article_adapter = ArticleExporterAdapter(index, document)
+    article_adapter.export()
+
 
 def extract_and_export_documents(
     index:str,

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -8,11 +8,17 @@ from tqdm import tqdm
 import articlemeta.client as articlemeta_client
 from xylose import scielodocument
 
+from exporter import interfaces, doaj
+
 
 logger = logging.getLogger(__name__)
 
 
 class ArticleMetaDocumentNotFound(Exception):
+    pass
+
+
+class InvalidIndexExporter(Exception):
     pass
 
 
@@ -31,6 +37,19 @@ class AMClient:
 
     def document(self, collection: str, pid: str) -> scielodocument.Article:
         return self._client.document(collection=collection, code=pid)
+
+
+class ArticleExporterAdapter(interfaces.IndexExporterInterface):
+    index_exporter: interfaces.IndexExporterInterface
+
+    def __init__(self, index: str, article: scielodocument.Article):
+        if index == "doaj":
+            self.index_exporter = doaj.DOAJDocument(article)
+        else:
+            raise InvalidIndexExporter()
+
+    def export(self):
+        request = self.index_exporter.get_request()
 
 
 class PoisonPill:

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -6,12 +6,12 @@ from xylose import scielodocument
 from exporter import AMClient, doaj
 
 
-class DOAJDocumentTest(TestCase):
+class DOAJExporterTest(TestCase):
     @vcr.use_cassette("tests/fixtures/vcr_cassettes/S0100-19651998000200002.yml")
     def setUp(self):
         client = AMClient()
         self.article = client.document(collection="scl", pid="S0100-19651998000200002")
-        self.doaj_document = doaj.DOAJDocument(article=self.article)
+        self.doaj_document = doaj.DOAJExporter(article=self.article)
 
     def test_bibjson_author(self):
         for author in self.article.authors:
@@ -52,20 +52,11 @@ class DOAJDocumentTest(TestCase):
             title, self.doaj_document.bibjson_title
         )
 
-    def test_get_request(self):
-        request = self.doaj_document.get_request()
-
-        expected = {
-            "bibjson": {
-                "author": self.doaj_document.bibjson_author,
-                "identifier": self.doaj_document.bibjson_identifier,
-                "title": self.doaj_document.bibjson_title,
-            },
-        }
-        self.assertEqual(request, expected)
+    def test_export(self):
+        pass
 
 
-class DOAJDocumentExceptionsTest(TestCase):
+class DOAJExporterExceptionsTest(TestCase):
     @vcr.use_cassette("tests/fixtures/vcr_cassettes/S0100-19651998000200002.yml")
     def setUp(self):
         client = AMClient()
@@ -73,18 +64,18 @@ class DOAJDocumentExceptionsTest(TestCase):
 
     def test_raises_exception_if_no_author(self):
         del self.article.data["article"]["v10"]    # v10: authors
-        with self.assertRaises(doaj.DOAJDocumentNoAuthorsException) as exc:
-            doaj.DOAJDocument(article=self.article)
+        with self.assertRaises(doaj.DOAJExporterNoAuthorsException) as exc:
+            doaj.DOAJExporter(article=self.article)
 
     def test_raises_exception_if_no_eissn_nor_pissn(self):
         self.article.journal.electronic_issn = None
         self.article.journal.print_issn = None
-        with self.assertRaises(doaj.DOAJDocumentNoISSNException) as exc:
-            doaj.DOAJDocument(article=self.article)
+        with self.assertRaises(doaj.DOAJExporterNoISSNException) as exc:
+            doaj.DOAJExporter(article=self.article)
 
     def test_sets_as_untitled_document_if_no_article_title(self):
         del self.article.data["article"]["v12"]    # v12: titles
-        doaj_document = doaj.DOAJDocument(article=self.article)
+        doaj_document = doaj.DOAJExporter(article=self.article)
 
         section_code = self.article.section_code
         original_lang = self.article.original_language()

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -53,6 +53,18 @@ class DOAJDocumentTest(TestCase):
             title, self.doaj_document.bibjson_title
         )
 
+    def test_get_request(self):
+        request = self.doaj_document.get_request()
+
+        expected = {
+            "bibjson": {
+                "author": self.doaj_document.bibjson_author,
+                "identifier": self.doaj_document.bibjson_identifier,
+                "title": self.doaj_document.bibjson_title,
+            },
+        }
+        self.assertEqual(request, expected)
+
 
 class DOAJDocumentExceptionsTest(TestCase):
     @vcr.use_cassette("tests/fixtures/vcr_cassettes/S0100-19651998000200002.yml")

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -1,0 +1,37 @@
+from unittest import TestCase, mock
+
+import vcr
+from xylose import scielodocument
+
+from exporter import AMClient, doaj
+
+
+class DOAJDocumentTest(TestCase):
+    @vcr.use_cassette("tests/fixtures/vcr_cassettes/S0100-19651998000200002.yml")
+    def setUp(self):
+        client = AMClient()
+        document = client.document(collection="scl", pid="S0100-19651998000200002")
+        self.article = scielodocument.Article(document)
+        self.doaj_document = doaj.DOAJDocument(article=self.article)
+
+    def test_bibjson_author(self):
+        for author in self.article.data.authors:
+            with self.subTest(author=author):
+                author_name = [author.get('given_names', ''), author.get('surname', '')]
+                self.assertIn(
+                    {"name": author_name},
+                    self.doaj_document.bibjson_author,
+                )
+
+
+class DOAJDocumentErrorsTest(TestCase):
+    @vcr.use_cassette("tests/fixtures/vcr_cassettes/S0100-19651998000200002.yml")
+    def setUp(self):
+        client = AMClient()
+        document = client.document(collection="scl", pid="S0100-19651998000200002")
+        self.article = scielodocument.Article(document)
+
+    def test_raises_exception_if_no_author(self):
+        del self.article.data.data["article"]["v10"]    # v10: authors
+        with self.assertRaises(doaj.DOAJDocumentNoAuthorsException) as exc:
+            doaj.DOAJDocument(article=self.article)

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -6,12 +6,12 @@ from xylose import scielodocument
 from exporter import AMClient, doaj
 
 
-class DOAJExporterTest(TestCase):
+class DOAJExporterXyloseArticleTest(TestCase):
     @vcr.use_cassette("tests/fixtures/vcr_cassettes/S0100-19651998000200002.yml")
     def setUp(self):
         client = AMClient()
         self.article = client.document(collection="scl", pid="S0100-19651998000200002")
-        self.doaj_document = doaj.DOAJExporter(article=self.article)
+        self.doaj_document = doaj.DOAJExporterXyloseArticle(article=self.article)
 
     def test_bibjson_author(self):
         for author in self.article.authors:
@@ -56,7 +56,7 @@ class DOAJExporterTest(TestCase):
         pass
 
 
-class DOAJExporterExceptionsTest(TestCase):
+class DOAJExporterXyloseArticleExceptionsTest(TestCase):
     @vcr.use_cassette("tests/fixtures/vcr_cassettes/S0100-19651998000200002.yml")
     def setUp(self):
         client = AMClient()
@@ -64,18 +64,18 @@ class DOAJExporterExceptionsTest(TestCase):
 
     def test_raises_exception_if_no_author(self):
         del self.article.data["article"]["v10"]    # v10: authors
-        with self.assertRaises(doaj.DOAJExporterNoAuthorsException) as exc:
-            doaj.DOAJExporter(article=self.article)
+        with self.assertRaises(doaj.DOAJExporterXyloseArticleNoAuthorsException) as exc:
+            doaj.DOAJExporterXyloseArticle(article=self.article)
 
     def test_raises_exception_if_no_eissn_nor_pissn(self):
         self.article.journal.electronic_issn = None
         self.article.journal.print_issn = None
-        with self.assertRaises(doaj.DOAJExporterNoISSNException) as exc:
-            doaj.DOAJExporter(article=self.article)
+        with self.assertRaises(doaj.DOAJExporterXyloseArticleNoISSNException) as exc:
+            doaj.DOAJExporterXyloseArticle(article=self.article)
 
     def test_sets_as_untitled_document_if_no_article_title(self):
         del self.article.data["article"]["v12"]    # v12: titles
-        doaj_document = doaj.DOAJExporter(article=self.article)
+        doaj_document = doaj.DOAJExporterXyloseArticle(article=self.article)
 
         section_code = self.article.section_code
         original_lang = self.article.original_language()

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -23,6 +23,22 @@ class DOAJDocumentTest(TestCase):
                     self.doaj_document.bibjson_author,
                 )
 
+    def test_bibjson_identifier(self):
+        issn = self.article.data.journal.any_issn()
+        if issn == self.article.data.journal.electronic_issn:
+            issn_type = "eissn"
+        else:
+            issn_type = "pissn"
+
+        self.assertIn(
+            {"id": issn, "type": issn_type},
+            self.doaj_document.bibjson_identifier,
+        )
+        self.assertIn(
+            {"id": self.article.data.doi, "type": "doi"},
+            self.doaj_document.bibjson_identifier,
+        )
+
 
 class DOAJDocumentErrorsTest(TestCase):
     @vcr.use_cassette("tests/fixtures/vcr_cassettes/S0100-19651998000200002.yml")
@@ -34,4 +50,10 @@ class DOAJDocumentErrorsTest(TestCase):
     def test_raises_exception_if_no_author(self):
         del self.article.data.data["article"]["v10"]    # v10: authors
         with self.assertRaises(doaj.DOAJDocumentNoAuthorsException) as exc:
+            doaj.DOAJDocument(article=self.article)
+
+    def test_raises_exception_if_no_eissn_nor_pissn(self):
+        self.article.data.journal.electronic_issn = None
+        self.article.data.journal.print_issn = None
+        with self.assertRaises(doaj.DOAJDocumentNoISSNException) as exc:
             doaj.DOAJDocument(article=self.article)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -76,7 +76,7 @@ class ExportDocumentTest(TestCase):
     def test_amclient_document_called(self):
         mk_document = mock.Mock()
         export_document(
-            mk_document, collection="scl", pid="S0100-19651998000200002"
+            mk_document, index="doaj", collection="scl", pid="S0100-19651998000200002"
         )
         mk_document.assert_called_with(collection="scl", pid="S0100-19651998000200002")
 
@@ -84,7 +84,10 @@ class ExportDocumentTest(TestCase):
         mk_document = mock.Mock(side_effect=Exception("No document found"))
         with self.assertRaises(Exception) as exc_info:
             export_document(
-                mk_document, collection="scl", pid="S0100-19651998000200002"
+                mk_document,
+                index="doaj",
+                collection="scl",
+                pid="S0100-19651998000200002",
             )
         self.assertEqual(str(exc_info.exception), "No document found")
 
@@ -92,7 +95,10 @@ class ExportDocumentTest(TestCase):
         mk_document = mock.Mock(return_value=None)
         with self.assertRaises(ArticleMetaDocumentNotFound) as exc_info:
             export_document(
-                mk_document, collection="scl", pid="S0100-19651998000200002"
+                mk_document,
+                index="doaj",
+                collection="scl",
+                pid="S0100-19651998000200002",
             )
 
 
@@ -100,13 +106,17 @@ class ExtractAndExportDocumentsTest(TestCase):
     @mock.patch("exporter.main.AMClient")
     def test_instanciates_AMClient(self, MockAMClient):
         extract_and_export_documents(
-            collection="scl", pids=["S0100-19651998000200002"], connection="thrift"
+            index="doaj",
+            collection="scl",
+            pids=["S0100-19651998000200002"],
+            connection="thrift",
         )
         MockAMClient.assert_called_with(connection="thrift")
 
     @mock.patch("exporter.main.AMClient")
     def test_instanciates_AMClient_with_another_domain(self, MockAMClient):
         extract_and_export_documents(
+            index="doaj",
             collection="scl",
             pids=["S0100-19651998000200002"],
             domain="http://anotheram.scielo.org",
@@ -120,10 +130,14 @@ class ExtractAndExportDocumentsTest(TestCase):
         self, mk_get_document, mk_export_document, MockPoisonPill
     ):
         extract_and_export_documents(
-            collection="scl", pids=["S0100-19651998000200002"], connection="thrift"
+            index="doaj",
+            collection="scl",
+            pids=["S0100-19651998000200002"],
+            connection="thrift",
         )
         mk_export_document.assert_called_with(
             get_document=mk_get_document,
+            index="doaj",
             collection="scl",
             pid="S0100-19651998000200002",
             poison_pill=MockPoisonPill(),
@@ -137,11 +151,12 @@ class ExtractAndExportDocumentsTest(TestCase):
     ):
         pids = [f"S0100-1965199800020000{num}" for num in range(1, 4)]
         extract_and_export_documents(
-            collection="scl", pids=pids, connection="thrift"
+            index="doaj", collection="scl", pids=pids, connection="thrift"
         )
         for pid in pids:
             mk_export_document.assert_any_call(
                 get_document=mk_get_document,
+                index="doaj",
                 collection="scl",
                 pid=pid,
                 poison_pill=MockPoisonPill(),
@@ -157,7 +172,10 @@ class ExtractAndExportDocumentsTest(TestCase):
         exc = ArticleMetaDocumentNotFound()
         mk_export_document.side_effect = exc
         extract_and_export_documents(
-            collection="scl", pids=["S0100-19651998000200002"], connection="thrift"
+            index="doaj",
+            collection="scl",
+            pids=["S0100-19651998000200002"],
+            connection="thrift",
         )
         mk_logger_error.assert_called_once_with(
             "Não foi possível exportar documento '%s': '%s'.",
@@ -181,7 +199,7 @@ class MainExporterTest(TestCase):
             ]
         )
         mk_extract_and_export_documents.assert_called_with(
-            collection="spa", pids=["S0100-19651998000200002"]
+            index="doaj", collection="spa", pids=["S0100-19651998000200002"]
         )
 
     @mock.patch("exporter.main.extract_and_export_documents")
@@ -206,5 +224,5 @@ class MainExporterTest(TestCase):
                 ]
             )
         mk_extract_and_export_documents.assert_called_with(
-            collection="spa", pids=pids
+            index="doaj", collection="spa", pids=pids
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -73,7 +73,9 @@ class ArticleAdapterTest(TestCase):
 
 
 class ExportDocumentTest(TestCase):
-    def test_amclient_document_called(self):
+
+    @mock.patch("exporter.main.ArticleExporterAdapter")
+    def test_amclient_document_called(self, MockArticleExporterAdapter):
         mk_document = mock.Mock()
         export_document(
             mk_document, index="doaj", collection="scl", pid="S0100-19651998000200002"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,7 +10,7 @@ from exporter import AMClient, extract_and_export_documents, doaj
 from exporter.main import (
     ArticleMetaDocumentNotFound,
     InvalidIndexExporter,
-    ArticleExporterAdapter,
+    XyloseArticleExporterAdapter,
     export_document,
     main_exporter,
 )
@@ -59,23 +59,23 @@ class ArticleAdapterTest(TestCase):
 
     def test_raises_exception_if_invalid_index(self):
         with self.assertRaises(InvalidIndexExporter) as exc:
-            article_exporter = ArticleExporterAdapter(
+            article_exporter = XyloseArticleExporterAdapter(
                 index="abc", article=self.article.data
             )
 
-    @mock.patch("exporter.doaj.DOAJExporter")
-    def test_export_calls_doaj_export(self, MockDOAJExporter):
-        article_exporter: doaj.DOAJExporter = ArticleExporterAdapter(
+    @mock.patch("exporter.doaj.DOAJExporterXyloseArticle")
+    def test_export_calls_doaj_export(self, MockDOAJExporterXyloseArticle):
+        article_exporter: doaj.DOAJExporterXyloseArticle = XyloseArticleExporterAdapter(
             index="doaj", article=self.article.data
         )
         article_exporter.export()
-        MockDOAJExporter.assert_called_once()
+        MockDOAJExporterXyloseArticle.assert_called_once()
 
 
 class ExportDocumentTest(TestCase):
 
-    @mock.patch("exporter.main.ArticleExporterAdapter")
-    def test_amclient_document_called(self, MockArticleExporterAdapter):
+    @mock.patch("exporter.main.XyloseArticleExporterAdapter")
+    def test_amclient_document_called(self, MockXyloseArticleExporterAdapter):
         mk_document = mock.Mock()
         export_document(
             mk_document, index="doaj", collection="scl", pid="S0100-19651998000200002"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -63,13 +63,13 @@ class ArticleAdapterTest(TestCase):
                 index="abc", article=self.article.data
             )
 
-    @mock.patch("exporter.doaj.DOAJDocument")
-    def test_export_calls_doaj_export(self, MockDOAJDocument):
-        article_exporter: doaj.DOAJDocument = ArticleExporterAdapter(
+    @mock.patch("exporter.doaj.DOAJExporter")
+    def test_export_calls_doaj_export(self, MockDOAJExporter):
+        article_exporter: doaj.DOAJExporter = ArticleExporterAdapter(
             index="doaj", article=self.article.data
         )
         article_exporter.export()
-        MockDOAJDocument.assert_called_once()
+        MockDOAJExporter.assert_called_once()
 
 
 class ExportDocumentTest(TestCase):


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona adaptador para artigos do Article Meta para o exportador. Foi criada uma classe para ser a interface com o DOAJ e o adaptador utiliza a classe para a determinada base de exportação dos dados.

#### Onde a revisão poderia começar?
O PR está organizado em commits, iniciar pelo 037bded.

#### Como este poderia ser testado manualmente?
Este PR só contempla a implementação inicial do adapter. O comando de exportação, contudo, deve continuar rodando sem erros.

#### Algum cenário de contexto que queira dar?
Ainda não é possível o envio dos dados, pois ainda não foi feita a implementação do Sender.

### Screenshots
N/A.

#### Quais são tickets relevantes?
.

### Referências
.