### PR TITLE
Adiciona módulo de configuração

### DIFF
--- a/exporter/config.py
+++ b/exporter/config.py
@@ -1,0 +1,9 @@
+import os
+import sys
+
+_default = dict(
+    DOAJ_API_URL="https://doaj.org/api/",
+)
+
+def get(var_name: str):
+    return os.environ.get(var_name, _default.get(var_name, ""))

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -33,6 +33,10 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
     def bibjson_title(self) -> str:
         return self._data["bibjson"]["title"]
 
+    @property
+    def bibjson_title(self) -> str:
+        return self._data["bibjson"]["title"]
+
     def add_bibjson_author(self, article: scielodocument.Article):
         if not article.authors:
             raise DOAJExporterXyloseArticleNoAuthorsException()

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,10 @@ install_requires =
   articlemetaapi >= 1.26
   tqdm >= 4.62
 
+[options.extras_require]
+tests =
+  vcrpy
+
 [options.entry_points]
 console_scripts =
     scielo-export = exporter:export_documents

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,14 @@
+from unittest import TestCase, mock
+
+from exporter import config
+
+
+class ConfigTest(TestCase):
+    @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
+    def test_get_doaj_api_key(self):
+        self.assertEqual(config.get("DOAJ_API_KEY"), "doaj-api-key-1234")
+
+    def test_get_default_doaj_api_url_if_no_envvar_set(self):
+        self.assertEqual(
+            config.get("DOAJ_API_URL"), config._default.get("DOAJ_API_URL")
+        )


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona módulo de configuração, responsável por centralizar as variáveis de configuração padrão e obter valores das variáveis de ambiente usadas pelo exportador. Assim, a configuração fica flexível para o uso em contêineres, facilitando a definição de variáveis em produção.

#### Onde a revisão poderia começar?
Commit bb1f9e8.

#### Como este poderia ser testado manualmente?
1. Instale localmente o exportador: `pip install --editable .`
2. Abra um prompt Python e execute e importe o módulo `config`: `from exporter import config`
3. Execute o comando `config.get("DOAJ_API_URL")` e o retorno deve ser igual à `'https://doaj.org/api/'`
4. Execute o comando `config.get("DOAJ_API_KEY")` e o retorno deve ser igual à `''`
5. Execute o comando `config.get("PATH")` e o retorno deve ser igual ao Path do sistema operacional

#### Algum cenário de contexto que queira dar?
.

### Screenshots
N/A.

#### Quais são tickets relevantes?
.

### Referências
.
