### PR TITLE
Adiciona mecanismo para o CRUD POST /articles

### DIFF
--- a/exporter/config.py
+++ b/exporter/config.py
@@ -3,6 +3,7 @@ import sys
 
 _default = dict(
     DOAJ_API_URL="https://doaj.org/api/",
+    EXPORT_RUN_RETRIES=3,
 )
 
 def get(var_name: str):

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -166,10 +166,8 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
 
     def _add_bibjson_keywords(self, article: scielodocument.Article):
         keywords = article.keywords()
-        if keywords:
-            self._data["bibjson"].setdefault("keywords", [])
-            for keywords_to_send in keywords.values():
-                self._data["bibjson"]["keywords"] += keywords_to_send
+        if keywords and keywords.get(article.original_language()):
+            self._data["bibjson"]["keywords"] = keywords[article.original_language()]
 
     def _add_bibjson_link(self, article: scielodocument.Article):
         MIME_TYPE = {

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -51,6 +51,13 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
     def bibjson_title(self) -> str:
         return self._data["bibjson"]["title"]
 
+    @property
+    def post_request(self):
+        return {
+            "api_key": config.get("DOAJ_API_KEY"),
+            "article_json": self._data
+        }
+
     def add_bibjson_author(self, article: scielodocument.Article):
         if not article.authors:
             raise DOAJExporterXyloseArticleNoAuthorsException()
@@ -97,5 +104,4 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
         self._data["bibjson"]["title"] = title
 
     def export(self):
-        # Send request
         pass

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -30,6 +30,7 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
         self.add_bibjson_author(article)
         self.add_bibjson_identifier(article)
         self.add_bibjson_journal(article)
+        self.add_bibjson_keywords(article)
         self.add_bibjson_title(article)
 
     def _set_api_config(self):
@@ -60,6 +61,10 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
     @property
     def bibjson_journal(self) -> str:
         return self._data["bibjson"]["journal"]
+
+    @property
+    def bibjson_keywords(self) -> str:
+        return self._data["bibjson"].get("keywords")
 
     @property
     def bibjson_title(self) -> str:
@@ -134,6 +139,13 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
         _set_journal_field(journal, article, "title", "title", required=True)
 
         self._data["bibjson"]["journal"] = journal
+
+    def add_bibjson_keywords(self, article: scielodocument.Article):
+        keywords = article.keywords()
+        if keywords:
+            self._data["bibjson"].setdefault("keywords", [])
+            for keywords_to_send in keywords.values():
+                self._data["bibjson"]["keywords"] += keywords_to_send
 
     def add_bibjson_title(self, article: scielodocument.Article):
         title = article.original_title()

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -27,11 +27,11 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
         self._data = {}
         self._data["created_date"] = self._data["last_updated"] = now
         self._data.setdefault("bibjson", {})
-        self.add_bibjson_author(article)
         self.add_bibjson_identifier(article)
-        self.add_bibjson_journal(article)
-        self.add_bibjson_keywords(article)
-        self.add_bibjson_title(article)
+        self._add_bibjson_author(article)
+        self._add_bibjson_journal(article)
+        self._add_bibjson_keywords(article)
+        self._add_bibjson_title(article)
 
     def _set_api_config(self):
         for attr, envvar in [("_api_url", "DOAJ_API_URL"), ("_api_key", "DOAJ_API_KEY")]:
@@ -86,7 +86,7 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
     def error_response(self, response: dict) -> str:
         return response.get("error", "")
 
-    def add_bibjson_author(self, article: scielodocument.Article):
+    def _add_bibjson_author(self, article: scielodocument.Article):
         if not article.authors:
             raise DOAJExporterXyloseArticleNoAuthorsException()
 
@@ -114,7 +114,7 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
                 {"id": article.doi, "type": "doi"}
             )
 
-    def add_bibjson_journal(self, article: scielodocument.Article):
+    def _add_bibjson_journal(self, article: scielodocument.Article):
         journal = {}
 
         def _set_journal_field(journal, article, field, field_to_set, required=False):
@@ -140,14 +140,14 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
 
         self._data["bibjson"]["journal"] = journal
 
-    def add_bibjson_keywords(self, article: scielodocument.Article):
+    def _add_bibjson_keywords(self, article: scielodocument.Article):
         keywords = article.keywords()
         if keywords:
             self._data["bibjson"].setdefault("keywords", [])
             for keywords_to_send in keywords.values():
                 self._data["bibjson"]["keywords"] += keywords_to_send
 
-    def add_bibjson_title(self, article: scielodocument.Article):
+    def _add_bibjson_title(self, article: scielodocument.Article):
         title = article.original_title()
         if (
             not title and

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -68,8 +68,8 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
     @property
     def post_request(self) -> dict:
         return {
-            "api_key": config.get("DOAJ_API_KEY"),
-            "article_json": self._data
+            "params": {"api_key": config.get("DOAJ_API_KEY")},
+            "json": self._data
         }
 
     def post_response(self, response: dict) -> dict:

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -64,6 +64,9 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
             "status": response.get("status"),
         }
 
+    def error_response(self, response: dict) -> str:
+        return response.get("error", "")
+
     def add_bibjson_author(self, article: scielodocument.Article):
         if not article.authors:
             raise DOAJExporterXyloseArticleNoAuthorsException()

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -70,7 +70,9 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
 
         self._data["bibjson"].setdefault("author", [])
         for author in article.authors:
-            author_name = [author.get('given_names', ''), author.get('surname', '')]
+            author_name = " ".join(
+                [author.get('given_names', ''), author.get('surname', '')]
+            )
             self._data["bibjson"]["author"].append({"name": author_name})
 
     def add_bibjson_identifier(self, article: scielodocument.Article):

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -52,10 +52,16 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
         return self._data["bibjson"]["title"]
 
     @property
-    def post_request(self):
+    def post_request(self) -> dict:
         return {
             "api_key": config.get("DOAJ_API_KEY"),
             "article_json": self._data
+        }
+
+    def post_response(self, response: dict) -> dict:
+        return {
+            "index_id": response.get("id"),
+            "status": response.get("status"),
         }
 
     def add_bibjson_author(self, article: scielodocument.Article):

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -198,13 +198,6 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
 
     def _add_bibjson_title(self, article: scielodocument.Article):
         title = article.original_title()
-        if (
-            not title and
-            article.translated_titles() and
-            len(article.translated_titles()) != 0
-        ):
-            item = [(k, v) for k, v in article.translated_titles().items()][0]
-            title = item[1]
 
         if not title:
             section_code = article.section_code

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -32,6 +32,7 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
         self._data = {}
         self._data["created_date"] = self._data["last_updated"] = now
         self._data.setdefault("bibjson", {})
+        self._add_bibjson_abstract(article)
         self._add_bibjson_author(article)
         self._add_bibjson_identifier(article)
         self._add_bibjson_journal(article)
@@ -56,6 +57,10 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
     @property
     def last_updated(self) -> typing.List[dict]:
         return self._data["last_updated"]
+
+    @property
+    def bibjson_abstract(self) -> typing.List[dict]:
+        return self._data["bibjson"].get("abstract")
 
     @property
     def bibjson_author(self) -> typing.List[dict]:
@@ -96,6 +101,11 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
 
     def error_response(self, response: dict) -> str:
         return response.get("error", "")
+
+    def _add_bibjson_abstract(self, article: scielodocument.Article):
+        abstract = article.original_abstract()
+        if abstract:
+            self._data["bibjson"]["abstract"] = abstract
 
     def _add_bibjson_author(self, article: scielodocument.Article):
         if not article.authors:

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -2,7 +2,7 @@ import typing
 
 from xylose import scielodocument
 
-from exporter import interfaces, config
+from exporter import interfaces, config, utils
 
 
 class DOAJExporterXyloseArticleNoRequestData(Exception):
@@ -22,9 +22,10 @@ class DOAJExporterXyloseArticleNoISSNException(Exception):
 
 
 class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
-    def __init__(self, article: scielodocument.Article):
+    def __init__(self, article: scielodocument.Article, now: callable = utils.utcnow()):
         self._set_api_config()
         self._data = {}
+        self._data["created_date"] = self._data["last_updated"] = now
         self._data.setdefault("bibjson", {})
         self.add_bibjson_author(article)
         self.add_bibjson_identifier(article)
@@ -39,6 +40,14 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
             setattr(self, attr, config_var)
 
         self.crud_article_url = f"{self._api_url}articles"
+
+    @property
+    def created_date(self) -> typing.List[dict]:
+        return self._data["created_date"]
+
+    @property
+    def last_updated(self) -> typing.List[dict]:
+        return self._data["last_updated"]
 
     @property
     def bibjson_author(self) -> typing.List[dict]:

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -3,5 +3,9 @@ from abc import ABC, abstractmethod
 
 class IndexExporterInterface(ABC):
     @abstractmethod
+    def post_request(self):
+        pass
+
+    @abstractmethod
     def export(self):
         pass

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -3,7 +3,11 @@ from abc import ABC, abstractmethod
 
 class IndexExporterInterface(ABC):
     @abstractmethod
-    def post_request(self):
+    def post_request(self) -> dict:
+        pass
+
+    @abstractmethod
+    def post_response(self, response: dict) -> dict:
         pass
 
     @abstractmethod

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -11,5 +11,9 @@ class IndexExporterInterface(ABC):
         pass
 
     @abstractmethod
+    def error_response(self, response: dict) -> str:
+        pass
+
+    @abstractmethod
     def export(self):
         pass

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -77,7 +77,7 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
     )
     def _http_post_articles(self):
         return requests.post(
-            self.index_exporter.crud_article_url, data=self.post_request
+            url=self.index_exporter.crud_article_url, **self.post_request
         )
 
     def export(self):

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -55,10 +55,14 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
         else:
             raise InvalidIndexExporter()
         self.index = index
+        self._pid = article.data.get("code", "")
 
     @property
-    def post_request(self):
+    def post_request(self) -> dict:
         return self.index_exporter.post_request
+
+    def post_response(self, response: dict) -> dict:
+        return self.index_exporter.post_response(response)
 
     @tenacity.retry(
         wait=tenacity.wait_exponential(),
@@ -82,7 +86,9 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
                 f"Erro na exportação ao {self.index}: " + str(exc)
             )
         else:
-            return resp
+            export_result = self.post_response(resp.json())
+            export_result["pid"] = self._pid
+            return export_result
 
 
 class PoisonPill:

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -48,6 +48,10 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
         else:
             raise InvalidIndexExporter()
 
+    @property
+    def post_request(self):
+        return self.index_exporter.post_request
+
     def export(self):
         request = self.index_exporter.export()
 

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -186,7 +186,8 @@ def extract_and_export_documents(
 
         def write_result(result, path=output_path):
             output_file = pathlib.Path(path)
-            output_file.write_text(json.dumps(result) + "\n")
+            with output_file.open("a", encoding="utf-8") as fp:
+                fp.write(json.dumps(result) + "\n")
 
         def log_exception(exception, job, logger=logger):
             logger.error(

--- a/exporter/utils.py
+++ b/exporter/utils.py
@@ -1,0 +1,5 @@
+from datetime import datetime
+
+
+def utcnow():
+    return str(datetime.utcnow().isoformat() + "Z")

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ ply==3.11
 PyYAML==6.0
 requests==2.26.0
 six==1.16.0
+tenacity==8.0.1
 thriftpy2==0.4.14
 tqdm==4.62.3
 urllib3==1.26.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ python_requires = >=3.6
 install_requires =
   articlemetaapi >= 1.26
   tqdm >= 4.62
+  tenacity >= 8.0
 
 [options.extras_require]
 tests =

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,3 +12,8 @@ class ConfigTest(TestCase):
         self.assertEqual(
             config.get("DOAJ_API_URL"), config._default.get("DOAJ_API_URL")
         )
+
+    def test_get_default_export_run_retries_if_no_envvar_set(self):
+        self.assertEqual(
+            config.get("EXPORT_RUN_RETRIES"), config._default.get("EXPORT_RUN_RETRIES")
+        )

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -82,6 +82,15 @@ class DOAJExporterXyloseArticleTest(TestCase):
 
         self.assertEqual(expected, self.doaj_document.bibjson_journal)
 
+    def test_bibjson_keywords(self):
+        keywords = self.article.keywords()
+        expected = []
+        for kw_lang in keywords.values():
+            expected += kw_lang
+        self.assertEqual(
+            expected, self.doaj_document.bibjson_keywords
+        )
+
     def test_bibjson_title(self):
         title = self.article.original_title()
         if (
@@ -171,6 +180,12 @@ class DOAJExporterXyloseArticleExceptionsTest(TestCase):
             doaj.DOAJExporterXyloseArticleNoJournalRequiredFields
         ) as exc:
             doaj.DOAJExporterXyloseArticle(article=self.article)
+
+    def test_no_keywords_if_no_article_keywords(self):
+        del self.article.data["article"]["v85"]    # v85: keywords
+        doaj_document = doaj.DOAJExporterXyloseArticle(article=self.article)
+
+        self.assertIsNone(doaj_document.bibjson_keywords)
 
     def test_sets_as_untitled_document_if_no_article_title(self):
         del self.article.data["article"]["v12"]    # v12: titles

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -70,6 +70,31 @@ class DOAJExporterXyloseArticleTest(TestCase):
             expected, self.doaj_document.post_request
         )
 
+    def test_post_response_201(self):
+        fake_response = {
+          "id": "doaj-1234",
+          "location": "",
+          "status": "OK",
+        }
+        expected = {
+            "index_id": "doaj-1234",
+            "status": "OK",
+        }
+        self.assertEqual(
+            expected, self.doaj_document.post_response(fake_response)
+        )
+
+    def test_error_response(self):
+        fake_response = {
+          "id": "doaj-1234",
+          "location": "",
+          "status": "FAIL",
+          "error": "Fake Field is missing.",
+        }
+        self.assertEqual(
+            "Fake Field is missing.", self.doaj_document.error_response(fake_response)
+        )
+
 
 @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
 class DOAJExporterXyloseArticleExceptionsTest(TestCase):
@@ -111,4 +136,15 @@ class DOAJExporterXyloseArticleExceptionsTest(TestCase):
         self.assertEqual(
             self.article.issue.sections.get(section_code, {}).get(original_lang),
             doaj_document.bibjson_title,
+        )
+
+    def test_error_response_return_empty_str_if_no_error(self):
+        doaj_document = doaj.DOAJExporterXyloseArticle(article=self.article)
+        fake_response = {
+          "id": "doaj-1234",
+          "location": "",
+          "status": "FAIL",
+        }
+        self.assertEqual(
+            "", doaj_document.error_response(fake_response)
         )

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -23,7 +23,9 @@ class DOAJExporterXyloseArticleTest(TestCase):
     def test_bibjson_author(self):
         for author in self.article.authors:
             with self.subTest(author=author):
-                author_name = [author.get('given_names', ''), author.get('surname', '')]
+                author_name = " ".join(
+                    [author.get('given_names', ''), author.get('surname', '')]
+                )
                 self.assertIn(
                     {"name": author_name},
                     self.doaj_document.bibjson_author,

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -114,17 +114,8 @@ class DOAJExporterXyloseArticleTest(TestCase):
         )
 
     def test_bibjson_title(self):
-        title = self.article.original_title()
-        if (
-            not title and
-            self.article.translated_titles() and
-            len(self.article.translated_titles()) != 0
-        ):
-            item = [(k, v) for k, v in self.article.translated_titles().items()][0]
-            title = item[1]
-
         self.assertEqual(
-            title, self.doaj_document.bibjson_title
+            self.article.original_title(), self.doaj_document.bibjson_title
         )
 
     def test_post_request(self):

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -12,12 +12,29 @@ class DOAJExporterXyloseArticleTest(TestCase):
     def setUp(self):
         client = AMClient()
         self.article = client.document(collection="scl", pid="S0100-19651998000200002")
-        self.doaj_document = doaj.DOAJExporterXyloseArticle(article=self.article)
+        self.doaj_document = doaj.DOAJExporterXyloseArticle(
+            article=self.article, now=self._fake_utcnow()
+        )
+
+    def _fake_utcnow(self):
+        return "2021-01-01T00:00:00Z"
 
     def test_crud_article_url(self):
         self.assertEqual(
             config.get("DOAJ_API_URL") + "articles",
             self.doaj_document.crud_article_url,
+        )
+
+    def test_created_date(self):
+        self.assertEqual(
+            self._fake_utcnow(),
+            self.doaj_document.created_date,
+        )
+
+    def test_last_updated(self):
+        self.assertEqual(
+            self._fake_utcnow(),
+            self.doaj_document.last_updated,
         )
 
     def test_bibjson_author(self):

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -38,6 +38,12 @@ class DOAJExporterXyloseArticleTest(TestCase):
             self.doaj_document.last_updated,
         )
 
+    def test_bibjson_abstract(self):
+        abstract = self.article.original_abstract()
+        self.assertEqual(
+            abstract, self.doaj_document.bibjson_abstract
+        )
+
     def test_bibjson_author(self):
         for author in self.article.authors:
             with self.subTest(author=author):
@@ -169,6 +175,12 @@ class DOAJExporterXyloseArticleExceptionsTest(TestCase):
         with self.assertRaises(doaj.DOAJExporterXyloseArticleNoRequestData) as exc:
             doaj.DOAJExporterXyloseArticle(article=self.article)._api_key
         self.assertEqual("No DOAJ_API_KEY set", str(exc.exception))
+
+    def test_no_abstract_if_no_article_abstract(self):
+        del self.article.data["article"]["v83"]    # v83: abstract
+        doaj_document = doaj.DOAJExporterXyloseArticle(article=self.article)
+
+        self.assertIsNone(doaj_document.bibjson_abstract)
 
     def test_raises_exception_if_no_author(self):
         del self.article.data["article"]["v10"]    # v10: authors

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -85,9 +85,7 @@ class DOAJExporterXyloseArticleTest(TestCase):
 
     def test_bibjson_keywords(self):
         keywords = self.article.keywords()
-        expected = []
-        for kw_lang in keywords.values():
-            expected += kw_lang
+        expected = keywords.get(self.article.original_language())
         self.assertEqual(
             expected, self.doaj_document.bibjson_keywords
         )

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -59,8 +59,14 @@ class DOAJExporterXyloseArticleTest(TestCase):
             title, self.doaj_document.bibjson_title
         )
 
-    def test_export(self):
-        pass
+    def test_post_request(self):
+        expected = {
+            "api_key": config.get("DOAJ_API_KEY"),
+            "article_json": self.doaj_document._data
+        }
+        self.assertEqual(
+            expected, self.doaj_document.post_request
+        )
 
 
 @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -98,8 +98,8 @@ class DOAJExporterXyloseArticleTest(TestCase):
 
     def test_post_request(self):
         expected = {
-            "api_key": config.get("DOAJ_API_KEY"),
-            "article_json": self.doaj_document._data
+            "params": {"api_key": config.get("DOAJ_API_KEY")},
+            "json": self.doaj_document._data,
         }
         self.assertEqual(
             expected, self.doaj_document.post_request

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -3,15 +3,22 @@ from unittest import TestCase, mock
 import vcr
 from xylose import scielodocument
 
-from exporter import AMClient, doaj
+from exporter import AMClient, doaj, config
 
 
 class DOAJExporterXyloseArticleTest(TestCase):
     @vcr.use_cassette("tests/fixtures/vcr_cassettes/S0100-19651998000200002.yml")
+    @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
     def setUp(self):
         client = AMClient()
         self.article = client.document(collection="scl", pid="S0100-19651998000200002")
         self.doaj_document = doaj.DOAJExporterXyloseArticle(article=self.article)
+
+    def test_crud_article_url(self):
+        self.assertEqual(
+            config.get("DOAJ_API_URL") + "articles",
+            self.doaj_document.crud_article_url,
+        )
 
     def test_bibjson_author(self):
         for author in self.article.authors:
@@ -56,11 +63,24 @@ class DOAJExporterXyloseArticleTest(TestCase):
         pass
 
 
+@mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
 class DOAJExporterXyloseArticleExceptionsTest(TestCase):
     @vcr.use_cassette("tests/fixtures/vcr_cassettes/S0100-19651998000200002.yml")
     def setUp(self):
         client = AMClient()
         self.article = client.document(collection="scl", pid="S0100-19651998000200002")
+
+    @mock.patch.dict("os.environ", {"DOAJ_API_URL": ""})
+    def test_raises_exception_if_no_post_url(self):
+        with self.assertRaises(doaj.DOAJExporterXyloseArticleNoRequestData) as exc:
+            doaj.DOAJExporterXyloseArticle(article=self.article).post_url
+        self.assertEqual("No DOAJ_API_URL set", str(exc.exception))
+
+    @mock.patch.dict("os.environ", {"DOAJ_API_KEY": ""})
+    def test_raises_exception_if_no_api_key(self):
+        with self.assertRaises(doaj.DOAJExporterXyloseArticleNoRequestData) as exc:
+            doaj.DOAJExporterXyloseArticle(article=self.article)._api_key
+        self.assertEqual("No DOAJ_API_KEY set", str(exc.exception))
 
     def test_raises_exception_if_no_author(self):
         del self.article.data["article"]["v10"]    # v10: authors


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona envio de artigo via HTTP POST /api/articles para exportação de documento, com tratamento de erros e retentativas para falhas de conexão e timeout.

#### Onde a revisão poderia começar?
Commit 284a540.

#### Como este poderia ser testado manualmente?
1. Instale localmente o exportador: `pip install --editable .`
2. Configure variável de ambiente `DOAJ_API_KEY`com a API KEY do DOAJ
3. Executar o exportador com o PID de um documento: `scielo-export --output <caminho para arquivo de saída> doaj --collection <acrônimo da coleção> --pid <PID de artigo>`
4. A aplicação não deve ser interrompida por qualquer exceção HTTP
5. Em caso de sucesso, o resultado deverá estar salvo no arquivo cujo caminho foi passado no parâmetro `--output`

#### Algum cenário de contexto que queira dar?
.

### Screenshots
N/A.

#### Quais são tickets relevantes?
.

### Referências
.
