### PR TITLE
Adiciona atualização de artigos

### DIFF
--- a/exporter/__init__.py
+++ b/exporter/__init__.py
@@ -1,7 +1,7 @@
 import sys
 import logging
 
-from .main import AMClient, extract_and_export_documents, main_exporter
+from .main import AMClient, process_extracted_documents, main_exporter
 
 __all__ = [
     "AMClient",

--- a/exporter/config.py
+++ b/exporter/config.py
@@ -1,10 +1,18 @@
 import os
 import sys
 
+
+INITIAL_LOG_CONFIG = {
+    "format": "%(asctime)s %(levelname)-5.5s [%(name)s] %(message)s",
+    "filename": "exporter.log",
+}
+
+
 _default = dict(
     DOAJ_API_URL="https://doaj.org/api/",
     EXPORT_RUN_RETRIES=3,
 )
+
 
 def get(var_name: str):
     return os.environ.get(var_name, _default.get(var_name, ""))

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -218,3 +218,6 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
 
     def export(self):
         pass
+
+    def update(self):
+        pass

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -79,7 +79,20 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
         }
 
     def put_request(self, data: dict) -> dict:
-        pass
+        self._data = data
+        self._data["last_updated"] = self._now
+        self._data.setdefault("bibjson", {})
+        self._set_bibjson_abstract()
+        self._set_bibjson_author()
+        self._set_bibjson_identifier()
+        self._set_bibjson_journal()
+        self._set_bibjson_keywords()
+        self._set_bibjson_link()
+        self._set_bibjson_title()
+        return {
+            "params": {"api_key": config.get("DOAJ_API_KEY")},
+            "json": self._data
+        }
 
     def post_response(self, response: dict) -> dict:
         return {

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -106,6 +106,12 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
             "json": self._data
         }
 
+    @property
+    def get_request(self) -> dict:
+        return {
+            "params": {"api_key": config.get("DOAJ_API_KEY")},
+        }
+
     def post_response(self, response: dict) -> dict:
         return {
             "index_id": response.get("id"),

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -29,18 +29,11 @@ class DOAJExporterXyloseArticleNoDOINorlink(Exception):
 class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
     def __init__(self, article: scielodocument.Article, now: callable = utils.utcnow()):
         self._set_api_config()
+        self._article = article
+        self._now = now
         self._data = {}
         if article.data.get("doaj_id"):
             self._data["id"] = article.data["doaj_id"]
-        self._data["created_date"] = self._data["last_updated"] = now
-        self._data.setdefault("bibjson", {})
-        self._add_bibjson_abstract(article)
-        self._add_bibjson_author(article)
-        self._add_bibjson_identifier(article)
-        self._add_bibjson_journal(article)
-        self._add_bibjson_keywords(article)
-        self._add_bibjson_link(article)
-        self._add_bibjson_title(article)
 
     def _set_api_config(self):
         for attr, envvar in [("_api_url", "DOAJ_API_URL"), ("_api_key", "DOAJ_API_KEY")]:
@@ -101,6 +94,15 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
 
     @property
     def post_request(self) -> dict:
+        self._data["created_date"] = self._data["last_updated"] = self._now
+        self._data.setdefault("bibjson", {})
+        self._set_bibjson_abstract()
+        self._set_bibjson_author()
+        self._set_bibjson_identifier()
+        self._set_bibjson_journal()
+        self._set_bibjson_keywords()
+        self._set_bibjson_link()
+        self._set_bibjson_title()
         return {
             "params": {"api_key": config.get("DOAJ_API_KEY")},
             "json": self._data
@@ -124,25 +126,25 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
     def error_response(self, response: dict) -> str:
         return response.get("error", "")
 
-    def _add_bibjson_abstract(self, article: scielodocument.Article):
-        abstract = article.original_abstract()
+    def _set_bibjson_abstract(self):
+        abstract = self._article.original_abstract()
         if abstract:
             self._data["bibjson"]["abstract"] = abstract
 
-    def _add_bibjson_author(self, article: scielodocument.Article):
-        if not article.authors:
+    def _set_bibjson_author(self):
+        if not self._article.authors:
             raise DOAJExporterXyloseArticleNoAuthorsException()
 
         self._data["bibjson"].setdefault("author", [])
-        for author in article.authors:
+        for author in self._article.authors:
             author_name = " ".join(
                 [author.get('given_names', ''), author.get('surname', '')]
             )
             self._data["bibjson"]["author"].append({"name": author_name})
 
-    def _get_registered_journal_issn(self, article: scielodocument.Article):
+    def _get_registered_journal_issn(self):
         for journal_attr in ["electronic_issn", "print_issn"]:
-            issn = getattr(article.journal, journal_attr)
+            issn = getattr(self._article.journal, journal_attr)
             if not issn:
                 continue
 
@@ -161,53 +163,53 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
             raise DOAJExporterXyloseArticleNoISSNException()
 
 
-    def _add_bibjson_identifier(self, article: scielodocument.Article):
-        issn, issn_type = self._get_registered_journal_issn(article)
+    def _set_bibjson_identifier(self):
+        issn, issn_type = self._get_registered_journal_issn()
         self._data["bibjson"]["identifier"] = [{"id": issn, "type": issn_type}]
 
-        if article.doi:
+        if self._article.doi:
             self._data["bibjson"]["identifier"].append(
-                {"id": article.doi, "type": "doi"}
+                {"id": self._article.doi, "type": "doi"}
             )
 
-    def _add_bibjson_journal(self, article: scielodocument.Article):
+    def _set_bibjson_journal(self):
         journal = {}
 
         def _set_journal_field(journal, article, field, field_to_set, required=False):
-            journal_field = getattr(article.journal, field)
+            journal_field = getattr(self._article.journal, field)
             if journal_field:
                 journal[field_to_set] = journal_field
             elif not journal_field and required:
                 raise DOAJExporterXyloseArticleNoJournalRequiredFields()
 
 
-        publisher_country = article.journal.publisher_country
+        publisher_country = self._article.journal.publisher_country
         if not publisher_country:
             raise DOAJExporterXyloseArticleNoJournalRequiredFields()
         else:
             country_code, __ = publisher_country
             journal["country"] = country_code
 
-        _set_journal_field(journal, article, "languages", "language", required=True)
+        _set_journal_field(journal, self._article, "languages", "language", required=True)
         _set_journal_field(
-            journal, article, "publisher_name", "publisher", required=True
+            journal, self._article, "publisher_name", "publisher", required=True
         )
-        _set_journal_field(journal, article, "title", "title", required=True)
+        _set_journal_field(journal, self._article, "title", "title", required=True)
 
         self._data["bibjson"]["journal"] = journal
 
-    def _add_bibjson_keywords(self, article: scielodocument.Article):
-        keywords = article.keywords()
-        if keywords and keywords.get(article.original_language()):
-            self._data["bibjson"]["keywords"] = keywords[article.original_language()]
+    def _set_bibjson_keywords(self):
+        keywords = self._article.keywords()
+        if keywords and keywords.get(self._article.original_language()):
+            self._data["bibjson"]["keywords"] = keywords[self._article.original_language()]
 
-    def _add_bibjson_link(self, article: scielodocument.Article):
+    def _set_bibjson_link(self):
         MIME_TYPE = {
             "html": "text/html",
             "pdf": "application/pdf",
         }
 
-        fulltexts = article.fulltexts()
+        fulltexts = self._article.fulltexts()
         if fulltexts:
             self._data["bibjson"].setdefault("link", [])
             for content_type, links in fulltexts.items():
@@ -221,18 +223,18 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
                             }
                         )
 
-        if not (self._data["bibjson"].get("link") or article.doi):
+        if not (self._data["bibjson"].get("link") or self._article.doi):
             raise DOAJExporterXyloseArticleNoDOINorlink(
                 "Documento não possui DOI ou links para texto completo"
             )
 
-    def _add_bibjson_title(self, article: scielodocument.Article):
-        title = article.original_title()
+    def _set_bibjson_title(self):
+        title = self._article.original_title()
 
         if not title:
-            section_code = article.section_code
-            original_lang = article.original_language()
-            title = article.issue.sections.get(section_code, {}).get(
+            section_code = self._article.section_code
+            original_lang = self._article.original_language()
+            title = self._article.issue.sections.get(section_code, {}).get(
                 original_lang, "Documento sem título"
             )
 

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -112,6 +112,9 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
             "params": {"api_key": config.get("DOAJ_API_KEY")},
         }
 
+    def put_request(self, data: dict) -> dict:
+        pass
+
     def post_response(self, response: dict) -> dict:
         return {
             "index_id": response.get("id"),

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -216,8 +216,5 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
 
         self._data["bibjson"]["title"] = title
 
-    def export(self):
-        pass
-
-    def update(self):
+    def command_function(self):
         pass

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -57,42 +57,6 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
             return url
 
     @property
-    def created_date(self) -> typing.List[dict]:
-        return self._data["created_date"]
-
-    @property
-    def last_updated(self) -> typing.List[dict]:
-        return self._data["last_updated"]
-
-    @property
-    def bibjson_abstract(self) -> typing.List[dict]:
-        return self._data["bibjson"].get("abstract")
-
-    @property
-    def bibjson_author(self) -> typing.List[dict]:
-        return self._data["bibjson"]["author"]
-
-    @property
-    def bibjson_identifier(self) -> typing.List[dict]:
-        return self._data["bibjson"]["identifier"]
-
-    @property
-    def bibjson_journal(self) -> str:
-        return self._data["bibjson"]["journal"]
-
-    @property
-    def bibjson_keywords(self) -> str:
-        return self._data["bibjson"].get("keywords")
-
-    @property
-    def bibjson_link(self) -> str:
-        return self._data["bibjson"]["link"]
-
-    @property
-    def bibjson_title(self) -> str:
-        return self._data["bibjson"]["title"]
-
-    @property
     def post_request(self) -> dict:
         self._data["created_date"] = self._data["last_updated"] = self._now
         self._data.setdefault("bibjson", {})

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -17,3 +17,7 @@ class IndexExporterInterface(ABC):
     @abstractmethod
     def export(self):
         pass
+
+    @abstractmethod
+    def update(self):
+        pass

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -11,6 +11,10 @@ class IndexExporterInterface(ABC):
         pass
 
     @abstractmethod
+    def put_request(self, data: dict) -> dict:
+        pass
+
+    @abstractmethod
     def post_response(self, response: dict) -> dict:
         pass
 

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -15,9 +15,5 @@ class IndexExporterInterface(ABC):
         pass
 
     @abstractmethod
-    def export(self):
-        pass
-
-    @abstractmethod
-    def update(self):
+    def command_function(self):
         pass

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -7,6 +7,10 @@ class IndexExporterInterface(ABC):
         pass
 
     @abstractmethod
+    def get_request(self) -> dict:
+        pass
+
+    @abstractmethod
     def post_response(self, response: dict) -> dict:
         pass
 

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -292,10 +292,15 @@ def main_exporter(sargs):
         help="Caminho para arquivo de resultado da exportação",
     )
 
-    subparsers = parser.add_subparsers(title="Index", metavar="", dest="index")
+    subparsers = parser.add_subparsers(title="Index", dest="index", required=True)
 
-    doaj_parser = subparsers.add_parser(
-        "doaj", help="Base de indexação DOAJ", parents=[articlemeta_parser(sargs)],
+    doaj_parser = subparsers.add_parser("doaj", help="Base de indexação DOAJ")
+    doaj_export_subparsers = doaj_parser.add_subparsers(
+        title="DOAJ Command", dest="doaj_command", required=True,
+    )
+
+    doaj_export_subparsers.add_parser(
+        "export", help="Exporta documentos", parents=[articlemeta_parser(sargs)],
     )
 
     args = parser.parse_args(sargs)

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -130,7 +130,15 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
             return export_result
 
     def _update(self):
-        pass
+        resp = self._send_http_request(
+            requests.get, self.index_exporter.crud_article_url, **self.get_request,
+        )
+        try:
+            resp.raise_for_status()
+        except HTTPError as exc:
+            error_response = self.error_response(resp.json())
+            exc_msg = f"Erro na consulta ao {self.index}: {exc}. {error_response}"
+            raise IndexExporterHTTPError(exc_msg)
 
     def command_function(self):
         return self._command_function()

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -91,6 +91,10 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
     def post_request(self) -> dict:
         return self.index_exporter.post_request
 
+    @property
+    def get_request(self) -> dict:
+        return self.index_exporter.get_request
+
     def post_response(self, response: dict) -> dict:
         return self.index_exporter.post_response(response)
 

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -114,6 +114,9 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
             export_result["pid"] = self._pid
             return export_result
 
+    def update(self):
+        pass
+
 
 class PoisonPill:
     def __init__(self):

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -146,6 +146,14 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
                 self.index_exporter.crud_article_url,
                 **put_req,
             )
+            try:
+                put_resp.raise_for_status()
+            except HTTPError as exc:
+                error_response = self.error_response(put_resp.json())
+                exc_msg = f"Erro ao atualizar o {self.index}: {exc}. {error_response}"
+                raise IndexExporterHTTPError(exc_msg)
+            else:
+                return { "pid": self._pid, "status": "OK" }
 
     def command_function(self):
         return self._command_function()

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -95,6 +95,9 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
     def get_request(self) -> dict:
         return self.index_exporter.get_request
 
+    def put_request(self, data: dict) -> dict:
+        pass
+
     def post_response(self, response: dict) -> dict:
         return self.index_exporter.post_response(response)
 

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -179,7 +179,7 @@ def export_document(
     return article_adapter.export()
 
 
-def extract_and_export_documents(
+def process_extracted_documents(
     get_document:callable,
     index:str,
     output_path:pathlib.Path,
@@ -359,4 +359,4 @@ def main_exporter(sargs):
             params["pids_by_collection"].setdefault(doc["collection"], [])
             params["pids_by_collection"][doc["collection"]].append(doc["code"])
 
-    extract_and_export_documents(**params)
+    process_extracted_documents(**params)

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -104,13 +104,13 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
             (requests.ConnectionError, requests.Timeout),
         ),
     )
-    def _http_post_articles(self):
-        return requests.post(
-            url=self.index_exporter.crud_article_url, **self.post_request
-        )
+    def _send_http_request(self, request_method: callable, url: str, **request: json):
+        return request_method(url=url, **request)
 
-        resp = self._http_post_articles()
     def _export(self):
+        resp = self._send_http_request(
+            requests.post, self.index_exporter.crud_article_url, **self.post_request
+        )
         try:
             resp.raise_for_status()
         except HTTPError as exc:

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -96,7 +96,7 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
         return self.index_exporter.get_request
 
     def put_request(self, data: dict) -> dict:
-        pass
+        return self.index_exporter.put_request(data)
 
     def post_response(self, response: dict) -> dict:
         return self.index_exporter.post_response(response)
@@ -130,15 +130,22 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
             return export_result
 
     def _update(self):
-        resp = self._send_http_request(
+        get_resp = self._send_http_request(
             requests.get, self.index_exporter.crud_article_url, **self.get_request,
         )
         try:
-            resp.raise_for_status()
+            get_resp.raise_for_status()
         except HTTPError as exc:
-            error_response = self.error_response(resp.json())
+            error_response = self.error_response(get_resp.json())
             exc_msg = f"Erro na consulta ao {self.index}: {exc}. {error_response}"
             raise IndexExporterHTTPError(exc_msg)
+        else:
+            put_req = self.put_request(get_resp.json())
+            put_resp = self._send_http_request(
+                requests.put,
+                self.index_exporter.crud_article_url,
+                **put_req,
+            )
 
     def command_function(self):
         return self._command_function()

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -78,9 +78,9 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
             raise InvalidExporterInitData(f"Index informado inválido: {index}")
 
         if command == "export":
-            self.command_function = self.export
+            self._command_function = self._export
         elif command == "update":
-            self.command_function = self.update
+            self._command_function = self._update
         else:
             raise InvalidExporterInitData(f"Comando informado inválido: {command}")
 
@@ -109,8 +109,8 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
             url=self.index_exporter.crud_article_url, **self.post_request
         )
 
-    def export(self):
         resp = self._http_post_articles()
+    def _export(self):
         try:
             resp.raise_for_status()
         except HTTPError as exc:
@@ -122,8 +122,11 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
             export_result["pid"] = self._pid
             return export_result
 
-    def update(self):
+    def _update(self):
         pass
+
+    def command_function(self):
+        return self._command_function()
 
 
 class PoisonPill:

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -172,7 +172,7 @@ class JobExecutor:
                 raise
 
 
-def export_document(
+def process_document(
     get_document: callable,
     index: str,
     collection: str,
@@ -220,7 +220,7 @@ def process_extracted_documents(
             )
 
         executor = JobExecutor(
-            export_document,
+            process_document,
             max_workers=4,
             success_callback=write_result,
             exception_callback=log_exception,

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -109,7 +109,7 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
 
     def _export(self):
         resp = self._send_http_request(
-            requests.post, self.index_exporter.crud_article_url, **self.post_request
+            requests.post, self.index_exporter.crud_article_put_url, **self.post_request
         )
         try:
             resp.raise_for_status()

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -138,6 +138,12 @@ class DOAJExporterXyloseArticleTest(TestCase):
             expected, self.doaj_document.post_request
         )
 
+    def test_get_request(self):
+        expected = { "params": { "api_key": config.get("DOAJ_API_KEY") } }
+        self.assertEqual(
+            expected, self.doaj_document.get_request
+        )
+
     def test_post_response_201(self):
         fake_response = {
           "id": "doaj-1234",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -475,6 +475,31 @@ class ArticleMetaParserTest(TestCase):
 
 class MainExporterTest(TestCase):
     @mock.patch("exporter.main.extract_and_export_documents")
+    def test_raises_exception_if_no_index_command(
+        self, mk_extract_and_export_documents
+    ):
+        with self.assertRaises(SystemExit) as exc:
+            main_exporter(
+                [
+                    "--output",
+                    "output.log",
+                ]
+            )
+
+    @mock.patch("exporter.main.extract_and_export_documents")
+    def test_raises_exception_if_no_doaj_command(
+        self, mk_extract_and_export_documents
+    ):
+        with self.assertRaises(SystemExit) as exc:
+            main_exporter(
+                [
+                    "--output",
+                    "output.log",
+                    "doaj",
+                ]
+            )
+
+    @mock.patch("exporter.main.extract_and_export_documents")
     def test_raises_exception_if_no_dates_nor_pids(
         self, mk_extract_and_export_documents
     ):
@@ -484,6 +509,7 @@ class MainExporterTest(TestCase):
                     "--output",
                     "output.log",
                     "doaj",
+                    "export",
                 ]
             )
         self.assertEqual(
@@ -501,6 +527,7 @@ class MainExporterTest(TestCase):
                     "--output",
                     "output.log",
                     "doaj",
+                    "export",
                     "--pid",
                     "S0100-19651998000200002",
                 ]
@@ -528,6 +555,7 @@ class MainExporterTest(TestCase):
                         "--output",
                         "output.log",
                         "doaj",
+                        "export",
                         "--pids",
                         str(pids_file),
                     ]
@@ -545,6 +573,7 @@ class MainExporterTest(TestCase):
                 "--output",
                 "output.log",
                 "doaj",
+                "export",
                 "--connection",
                 "thrift",
                 "--collection",
@@ -565,6 +594,7 @@ class MainExporterTest(TestCase):
                 "--output",
                 "output.log",
                 "doaj",
+                "export",
                 "--domain",
                 "http://anotheram.scielo.org",
                 "--collection",
@@ -585,6 +615,7 @@ class MainExporterTest(TestCase):
                 "--output",
                 "output.log",
                 "doaj",
+                "export",
                 "--collection",
                 "spa",
                 "--pid",
@@ -616,6 +647,7 @@ class MainExporterTest(TestCase):
                     "--output",
                     "output.log",
                     "doaj",
+                    "export",
                     "--collection",
                     "spa",
                     "--pids",
@@ -650,6 +682,7 @@ class MainExporterTest(TestCase):
                     "--output",
                     "output.log",
                     "doaj",
+                    "export",
                 ] +
                 args
             )
@@ -695,6 +728,7 @@ class MainExporterTest(TestCase):
                         "--output",
                         "output.log",
                         "doaj",
+                        "export",
                     ] +
                     args
                 )
@@ -731,6 +765,7 @@ class MainExporterTest(TestCase):
                 "--output",
                 "output.log",
                 "doaj",
+                "export",
                 "--from-date",
                 "01-01-2021",
                 "--until-date",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -473,7 +473,7 @@ class ArticleMetaParserTest(TestCase):
         self.assertEqual(str(args.domain), "http://anotheram.scielo.org")
 
 
-class MainExporterTest(TestCase):
+class MainExporterTestMixin:
     @mock.patch("exporter.main.extract_and_export_documents")
     def test_raises_exception_if_no_index_command(
         self, mk_extract_and_export_documents
@@ -495,7 +495,7 @@ class MainExporterTest(TestCase):
                 [
                     "--output",
                     "output.log",
-                    "doaj",
+                    self.index,
                 ]
             )
 
@@ -508,8 +508,8 @@ class MainExporterTest(TestCase):
                 [
                     "--output",
                     "output.log",
-                    "doaj",
-                    "export",
+                    self.index,
+                    self.index_command,
                 ]
             )
         self.assertEqual(
@@ -526,8 +526,8 @@ class MainExporterTest(TestCase):
                 [
                     "--output",
                     "output.log",
-                    "doaj",
-                    "export",
+                    self.index,
+                    self.index_command,
                     "--pid",
                     "S0100-19651998000200002",
                 ]
@@ -554,8 +554,8 @@ class MainExporterTest(TestCase):
                     [
                         "--output",
                         "output.log",
-                        "doaj",
-                        "export",
+                        self.index,
+                        self.index_command,
                         "--pids",
                         str(pids_file),
                     ]
@@ -572,8 +572,8 @@ class MainExporterTest(TestCase):
             [
                 "--output",
                 "output.log",
-                "doaj",
-                "export",
+                self.index,
+                self.index_command,
                 "--connection",
                 "thrift",
                 "--collection",
@@ -593,8 +593,8 @@ class MainExporterTest(TestCase):
             [
                 "--output",
                 "output.log",
-                "doaj",
-                "export",
+                self.index,
+                self.index_command,
                 "--domain",
                 "http://anotheram.scielo.org",
                 "--collection",
@@ -614,8 +614,8 @@ class MainExporterTest(TestCase):
             [
                 "--output",
                 "output.log",
-                "doaj",
-                "export",
+                self.index,
+                self.index_command,
                 "--collection",
                 "spa",
                 "--pid",
@@ -624,7 +624,7 @@ class MainExporterTest(TestCase):
         )
         mk_extract_and_export_documents.assert_called_with(
             get_document=mk_document,
-            index="doaj",
+            index=self.index,
             output_path=pathlib.Path("output.log"),
             pids_by_collection={"spa": ["S0100-19651998000200002"]},
         )
@@ -646,8 +646,8 @@ class MainExporterTest(TestCase):
                 [
                     "--output",
                     "output.log",
-                    "doaj",
-                    "export",
+                    self.index,
+                    self.index_command,
                     "--collection",
                     "spa",
                     "--pids",
@@ -656,7 +656,7 @@ class MainExporterTest(TestCase):
             )
         mk_extract_and_export_documents.assert_called_with(
             get_document=mk_document,
-            index="doaj",
+            index=self.index,
             output_path=pathlib.Path("output.log"),
             pids_by_collection={"spa": pids},
         )
@@ -681,8 +681,8 @@ class MainExporterTest(TestCase):
                 [
                     "--output",
                     "output.log",
-                    "doaj",
-                    "export",
+                    self.index,
+                    self.index_command,
                 ] +
                 args
             )
@@ -727,8 +727,8 @@ class MainExporterTest(TestCase):
                     [
                         "--output",
                         "output.log",
-                        "doaj",
-                        "export",
+                        self.index,
+                        self.index_command,
                     ] +
                     args
                 )
@@ -764,8 +764,8 @@ class MainExporterTest(TestCase):
             [
                 "--output",
                 "output.log",
-                "doaj",
-                "export",
+                self.index,
+                self.index_command,
                 "--from-date",
                 "01-01-2021",
                 "--until-date",
@@ -774,7 +774,7 @@ class MainExporterTest(TestCase):
         )
         mk_extract_and_export_documents.assert_called_once_with(
             get_document=mk_document,
-            index="doaj",
+            index=self.index,
             output_path=pathlib.Path("output.log"),
             pids_by_collection={
                 "scl": ["S0101-01019000090090097"],
@@ -782,3 +782,8 @@ class MainExporterTest(TestCase):
                 "cub": ["S0303-01019000090090099"],
             },
         )
+
+
+class DOAJExportMainExporterTest(MainExporterTestMixin, TestCase):
+    index = "doaj"
+    index_command = "export"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -220,6 +220,50 @@ class UpdateXyloseArticleExporterAdapterTest(
     def setUp(self):
         client = AMClient()
         self.article = client.document(collection="scl", pid="S0100-19651998000200002")
+        self.article.data["doaj_id"] = "doaj-id-123456"
+
+    @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
+    @mock.patch("exporter.main.requests")
+    @mock.patch(
+        "exporter.main.doaj.DOAJExporterXyloseArticle.get_request",
+        new_callable=mock.PropertyMock,
+    )
+    def test_update_calls_requests_get_to_doaj_api_with_doaj_get_request(
+        self, mk_get_request, mk_requests
+    ):
+        mk_get_request.return_value = { "params": {"api_key": "doaj-api-key-1234"} }
+        article_exporter = XyloseArticleExporterAdapter(
+            index=self.index, command=self.index_command, article=self.article
+        )
+        crud_article_url = article_exporter.index_exporter.crud_article_url
+
+        article_exporter.command_function()
+        mk_requests.get.assert_called_once_with(
+            url=crud_article_url,
+            **{ "params": { "api_key": "doaj-api-key-1234" } },
+        )
+
+    @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
+    @mock.patch("exporter.main.requests")
+    def test_update_raises_exception_if_get_raises_http_error(self, mk_requests):
+        mock_resp = mock.Mock()
+        mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "HTTP Error"
+        )
+        mk_requests.get.return_value = mock_resp
+        mk_requests.get.return_value.json.return_value = {
+            "id": "doaj-id",
+            "error": "wrong field.",
+        }
+
+        article_exporter = XyloseArticleExporterAdapter(
+            index=self.index, command=self.index_command, article=self.article
+        )
+        with self.assertRaises(IndexExporterHTTPError) as exc:
+            article_exporter.command_function()
+        self.assertEqual(
+            "Erro na consulta ao doaj: HTTP Error. wrong field.", str(exc.exception)
+        )
 
 
 class ProcessDocumentTestMixin:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -151,16 +151,19 @@ class ExportXyloseArticleExporterAdapterTest(
             new_callable=mock.PropertyMock,
         ) as mk_post_request:
             mk_post_request.return_value = {
-                "api_key": "doaj-api-key-1234",
+                "params": {"api_key": "doaj-api-key-1234"},
                 "json": {"field": "value"},
             }
-            article_exporter: doaj.DOAJExporterXyloseArticle = XyloseArticleExporterAdapter(
-                index=self.index, command=self.index_command, article=self.article
+            article_exporter = XyloseArticleExporterAdapter(
+                index=self.index, command=self.index_command, article=self.article,
             )
             article_exporter.command_function()
             mk_requests.post.assert_called_once_with(
-                url=article_exporter.index_exporter.crud_article_url,
-                **{"api_key": "doaj-api-key-1234", "json": {"field": "value"}},
+                url=article_exporter.index_exporter.crud_article_put_url,
+                **{
+                    "params": {"api_key": "doaj-api-key-1234"},
+                    "json": {"field": "value"},
+                },
             )
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona funcionalidade de atualização de artigos implementando método HTTP PUT do CRUD do DOAJ para atualizar artigos. Para esta funcionalidade, também é necessário implementar o HTTP GET, pois a API do DOAJ não aceita atualizações parciais do artigo.

#### Onde a revisão poderia começar?
Commit 36268c7.

#### Como este poderia ser testado manualmente?
1. Instale localmente o exportador: `pip install --editable .`
2. Configure variável de ambiente `DOAJ_API_KEY`com a API KEY do DOAJ
3. Executar o exportador com o PID de um documento: `scielo-export --output <caminho para arquivo de saída> doaj update --collection <acrônimo da coleção> --pid <PID de artigo>`
4. A aplicação não deve ser interrompida por qualquer exceção HTTP
5. Em caso de sucesso, o resultado deverá estar salvo no arquivo cujo caminho foi passado no parâmetro `--output`

#### Algum cenário de contexto que queira dar?
.

### Screenshots
N/A.

#### Quais são tickets relevantes?
.

### Referências
.
