### PR TITLE
Adiciona consulta de artigos

### DIFF
--- a/exporter/main.py
+++ b/exporter/main.py
@@ -200,7 +200,7 @@ class JobExecutor:
                     except Exception as exc:
                         self.exception_callback(exc, job)
                     else:
-                        self.success_callback(result)
+                        self.success_callback(result, job)
                     finally:
                         self.update_bar()
             except KeyboardInterrupt:
@@ -254,10 +254,16 @@ def process_extracted_documents(
         def update_bar(pbar=pbar):
             pbar.update(1)
 
-        def write_result(result, path:pathlib.Path=output_path):
-            logger.debug('Gravando resultado em arquivo %s: "%s"', path, result)
-            with path.open("a", encoding="utf-8") as fp:
-                fp.write(json.dumps(result) + "\n")
+        def write_result(result, job, path:pathlib.Path=output_path):
+            if path.is_dir():
+                file_path = path / f'{job["pid"]}.json'
+                logger.debug('Gravando resultado em arquivo %s: "%s"', file_path)
+                with file_path.open("w", encoding="utf-8") as fp:
+                    json.dump(result, fp)
+            else:
+                logger.debug('Gravando resultado em arquivo %s: "%s"', path, result)
+                with path.open("a", encoding="utf-8") as fp:
+                    fp.write(json.dumps(result) + "\n")
 
         def log_exception(exception, job, logger=logger):
             logger.error(

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -140,9 +140,9 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
         try:
             get_resp.raise_for_status()
         except HTTPError as exc:
-            error_response = self.error_response(get_resp.json())
-            exc_msg = f"Erro na consulta ao {self.index}: {exc}. {error_response}"
-            raise IndexExporterHTTPError(exc_msg)
+            raise IndexExporterHTTPError(
+                f"Erro na consulta ao {self.index}: {exc}."
+            )
         else:
             put_req = self.put_request(get_resp.json())
             put_resp = self._send_http_request(
@@ -168,9 +168,9 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
         try:
             get_resp.raise_for_status()
         except HTTPError as exc:
-            error_response = self.error_response(get_resp.json())
-            exc_msg = f"Erro na consulta ao {self.index}: {exc}. {error_response}"
-            raise IndexExporterHTTPError(exc_msg)
+            raise IndexExporterHTTPError(
+                f"Erro na consulta ao {self.index}: {exc}."
+            )
         else:
             get_result = get_resp.json()
             get_result["pid"] = self._pid

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -365,6 +365,10 @@ def main_exporter(sargs):
         "update", help="Atualiza documentos", parents=[articlemeta_parser(sargs)],
     )
 
+    doaj_export_subparsers.add_parser(
+        "get", help="Obtém documentos", parents=[articlemeta_parser(sargs)],
+    )
+
     args = parser.parse_args(sargs)
 
     if not (args.from_date or args.until_date or args.pid or args.pids):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 import tempfile
 import pathlib
 import json
+import shutil
 from unittest import TestCase, mock
 from datetime import datetime, timedelta
 
@@ -712,7 +713,7 @@ class MainExporterTestMixin:
             main_exporter(
                 [
                     "--output",
-                    "output.log",
+                    str(self.output_path),
                 ]
             )
 
@@ -724,7 +725,7 @@ class MainExporterTestMixin:
             main_exporter(
                 [
                     "--output",
-                    "output.log",
+                    str(self.output_path),
                     self.index,
                 ]
             )
@@ -737,7 +738,7 @@ class MainExporterTestMixin:
             main_exporter(
                 [
                     "--output",
-                    "output.log",
+                    str(self.output_path),
                     self.index,
                     self.index_command,
                 ]
@@ -755,7 +756,7 @@ class MainExporterTestMixin:
             main_exporter(
                 [
                     "--output",
-                    "output.log",
+                    str(self.output_path),
                     self.index,
                     self.index_command,
                     "--pid",
@@ -783,7 +784,7 @@ class MainExporterTestMixin:
                 main_exporter(
                     [
                         "--output",
-                        "output.log",
+                        str(self.output_path),
                         self.index,
                         self.index_command,
                         "--pids",
@@ -801,7 +802,7 @@ class MainExporterTestMixin:
         main_exporter(
             [
                 "--output",
-                "output.log",
+                str(self.output_path),
                 self.index,
                 self.index_command,
                 "--connection",
@@ -822,7 +823,7 @@ class MainExporterTestMixin:
         main_exporter(
             [
                 "--output",
-                "output.log",
+                str(self.output_path),
                 self.index,
                 self.index_command,
                 "--domain",
@@ -843,7 +844,7 @@ class MainExporterTestMixin:
         main_exporter(
             [
                 "--output",
-                "output.log",
+                str(self.output_path),
                 self.index,
                 self.index_command,
                 "--collection",
@@ -856,7 +857,7 @@ class MainExporterTestMixin:
             get_document=mk_document,
             index=self.index,
             index_command=self.index_command,
-            output_path=pathlib.Path("output.log"),
+            output_path=self.output_path,
             pids_by_collection={"spa": ["S0100-19651998000200002"]},
         )
 
@@ -876,7 +877,7 @@ class MainExporterTestMixin:
             main_exporter(
                 [
                     "--output",
-                    "output.log",
+                    str(self.output_path),
                     self.index,
                     self.index_command,
                     "--collection",
@@ -889,7 +890,7 @@ class MainExporterTestMixin:
             get_document=mk_document,
             index=self.index,
             index_command=self.index_command,
-            output_path=pathlib.Path("output.log"),
+            output_path=self.output_path,
             pids_by_collection={"spa": pids},
         )
 
@@ -912,7 +913,7 @@ class MainExporterTestMixin:
             main_exporter(
                 [
                     "--output",
-                    "output.log",
+                    str(self.output_path),
                     self.index,
                     self.index_command,
                 ] +
@@ -958,7 +959,7 @@ class MainExporterTestMixin:
                 main_exporter(
                     [
                         "--output",
-                        "output.log",
+                        str(self.output_path),
                         self.index,
                         self.index_command,
                     ] +
@@ -995,7 +996,7 @@ class MainExporterTestMixin:
         main_exporter(
             [
                 "--output",
-                "output.log",
+                str(self.output_path),
                 self.index,
                 self.index_command,
                 "--from-date",
@@ -1008,7 +1009,7 @@ class MainExporterTestMixin:
             get_document=mk_document,
             index=self.index,
             index_command=self.index_command,
-            output_path=pathlib.Path("output.log"),
+            output_path=self.output_path,
             pids_by_collection={
                 "scl": ["S0101-01019000090090097"],
                 "arg": ["S0202-01019000090090098"],
@@ -1020,8 +1021,21 @@ class MainExporterTestMixin:
 class DOAJExportMainExporterTest(MainExporterTestMixin, TestCase):
     index = "doaj"
     index_command = "export"
+    output_path = pathlib.Path("output.log")
 
 
 class DOAJUpdateMainExporterTest(MainExporterTestMixin, TestCase):
     index = "doaj"
     index_command = "update"
+    output_path = pathlib.Path("output.log")
+
+
+class DOAJGetMainExporterTest(MainExporterTestMixin, TestCase):
+    index = "doaj"
+    index_command = "get"
+
+    def setUp(self):
+        self.output_path = pathlib.Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.output_path)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -466,7 +466,7 @@ class ProcessExtractedDocumentsTestMixin:
             get_document=self.mk_get_document,
             index=self.index,
             index_command=self.index_command,
-            output_path=pathlib.Path("output.log"),
+            output_path=self.output_path,
             pids_by_collection={"scl": ["S0100-19651998000200002"]},
         )
         mk_process_document.assert_called_with(
@@ -487,7 +487,7 @@ class ProcessExtractedDocumentsTestMixin:
             get_document=self.mk_get_document,
             index=self.index,
             index_command=self.index_command,
-            output_path=pathlib.Path("output.log"),
+            output_path=self.output_path,
             pids_by_collection={"scl": pids},
         )
         for pid in pids:
@@ -510,7 +510,7 @@ class ProcessExtractedDocumentsTestMixin:
                 get_document=self.mk_get_document,
                 index=self.index,
                 index_command=self.index_command,
-                output_path=pathlib.Path("output.log"),
+                output_path=self.output_path,
                 pids_by_collection={"scl": ["S0100-19651998000200001"]},
             )
             mk_logger_error.assert_called_once_with(
@@ -519,7 +519,19 @@ class ProcessExtractedDocumentsTestMixin:
                 exc
             )
 
-    def test_all_docs_successfully_posted_are_recorded_to_file(
+
+class ExportExtractedDocumentsTest(ProcessExtractedDocumentsTestMixin, TestCase):
+    index = "doaj"
+    index_command = "export"
+    output_path = pathlib.Path("output.log")
+
+    @vcr.use_cassette("tests/fixtures/vcr_cassettes/S0100-19651998000200002.yml")
+    def setUp(self):
+        self.mk_get_document = mock.MagicMock()
+
+    @mock.patch("exporter.main.PoisonPill")
+    @mock.patch("exporter.main.process_document")
+    def test_all_docs_successfully_exported_are_recorded_to_file(
         self, mk_process_document, MockPoisonPill
     ):
         fake_pids = [f"S0100-1965199800020000{count}" for count in range(1, 5)]
@@ -547,16 +559,45 @@ class ProcessExtractedDocumentsTestMixin:
                     self.assertIn(pid, file_content)
 
 
-class ExportExtractedDocumentsTest(ProcessExtractedDocumentsTestMixin, TestCase):
+class UpdateExtractedDocumentsTest(ProcessExtractedDocumentsTestMixin, TestCase):
     index = "doaj"
-    index_command = "export"
+    index_command = "update"
+    output_path = pathlib.Path("output.log")
 
     @vcr.use_cassette("tests/fixtures/vcr_cassettes/S0100-19651998000200002.yml")
     def setUp(self):
         self.mk_get_document = mock.MagicMock()
 
+    @mock.patch("exporter.main.PoisonPill")
+    @mock.patch("exporter.main.process_document")
+    def test_all_docs_successfully_updated_are_recorded_to_file(
+        self, mk_process_document, MockPoisonPill
+    ):
+        fake_pids = [f"S0100-1965199800020000{count}" for count in range(1, 5)]
+        fake_exported_docs = [
+            {
+                "index_id": f"doaj-{pid}",
+                "status": "OK",
+                "pid": pid,
+            }
+            for pid in fake_pids
+        ]
+        mk_process_document.side_effect = fake_exported_docs
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            output_file = pathlib.Path(tmpdirname) / "output.log"
+            process_extracted_documents(
+                get_document=self.mk_get_document,
+                index=self.index,
+                index_command=self.index_command,
+                output_path=output_file,
+                pids_by_collection={"scl": fake_pids},
+            )
+            file_content = output_file.read_text()
+            for pid in fake_pids:
+                with self.subTest(pid=pid):
+                    self.assertIn(pid, file_content)
 
-class UpdateExtractedDocumentsTest(ProcessExtractedDocumentsTestMixin, TestCase):
+
     index = "doaj"
     index_command = "update"
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -252,10 +252,6 @@ class UpdateXyloseArticleExporterAdapterTest(
             "HTTP Error"
         )
         mk_requests.get.return_value = mock_resp
-        mk_requests.get.return_value.json.return_value = {
-            "id": "doaj-id",
-            "error": "wrong field.",
-        }
 
         article_exporter = XyloseArticleExporterAdapter(
             index=self.index, command=self.index_command, article=self.article
@@ -263,7 +259,7 @@ class UpdateXyloseArticleExporterAdapterTest(
         with self.assertRaises(IndexExporterHTTPError) as exc:
             article_exporter.command_function()
         self.assertEqual(
-            "Erro na consulta ao doaj: HTTP Error. wrong field.", str(exc.exception)
+            "Erro na consulta ao doaj: HTTP Error.", str(exc.exception)
         )
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
@@ -411,10 +407,6 @@ class GetXyloseArticleExporterAdapterTest(
             "HTTP Error"
         )
         mk_requests.get.return_value = mock_resp
-        mk_requests.get.return_value.json.return_value = {
-            "id": "doaj-id",
-            "error": "wrong field.",
-        }
 
         article_exporter = XyloseArticleExporterAdapter(
             index=self.index, command=self.index_command, article=self.article
@@ -422,7 +414,7 @@ class GetXyloseArticleExporterAdapterTest(
         with self.assertRaises(IndexExporterHTTPError) as exc:
             article_exporter.command_function()
         self.assertEqual(
-            "Erro na consulta ao doaj: HTTP Error. wrong field.", str(exc.exception)
+            "Erro na consulta ao doaj: HTTP Error.", str(exc.exception)
         )
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona funcionalidade de consulta de artigos implementando método HTTP GET do CRUD do DOAJ. Em caso de sucesso, o resultado será salvo no argumento `--output`. Se o argumento for um caminho de um diretório, o resultado de cada uma das consultas será salvo em um arquivo. Informando o caminho de um arquivo, o resultado esperado é o mesmo que o implementado anteriormente: cada resultado com sucesso é salvo no mesmo arquivo.

#### Onde a revisão poderia começar?
Commit 5c7e75a.

#### Como este poderia ser testado manualmente?
1. Instale localmente o exportador: `pip install --editable .`
2. Configure variável de ambiente `DOAJ_API_KEY`com a API KEY do DOAJ
3. Executar o exportador com o PID de um documento: `scielo-export --output <caminho para arquivo de saída> doaj get --collection <acrônimo da coleção> --pid <PID de artigo>`
4. A aplicação não deve ser interrompida por qualquer exceção HTTP
5. Em caso de sucesso, o resultado deverá estar salvo no arquivo ou diretório cujo caminho foi passado no parâmetro `--output`

#### Algum cenário de contexto que queira dar?
Conforme relatado em PR anterior, nem todos os artigos da fonte tem o ID do DOAJ e, nestes casos, não será possível efetuar a consulta.

### Screenshots
N/A.

#### Quais são tickets relevantes?
.

### Referências
.
