### PR TITLE
Adiciona deleção de artigos

### DIFF
--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -78,6 +78,12 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
             "params": {"api_key": config.get("DOAJ_API_KEY")},
         }
 
+    @property
+    def delete_request(self) -> dict:
+        return {
+            "params": {"api_key": config.get("DOAJ_API_KEY")},
+        }
+
     def put_request(self, data: dict) -> dict:
         self._data = data
         self._data["last_updated"] = self._now

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -11,6 +11,10 @@ class IndexExporterInterface(ABC):
         pass
 
     @abstractmethod
+    def delete_request(self) -> dict:
+        pass
+
+    @abstractmethod
     def put_request(self, data: dict) -> dict:
         pass
 

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -392,6 +392,10 @@ def main_exporter(sargs):
         "get", help="Obtém documentos", parents=[articlemeta_parser(sargs)],
     )
 
+    doaj_export_subparsers.add_parser(
+        "delete", help="Deleta documentos", parents=[articlemeta_parser(sargs)],
+    )
+
     args = parser.parse_args(sargs)
 
     if not (args.from_date or args.until_date or args.pid or args.pids):

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -305,7 +305,7 @@ def process_extracted_documents(
 
         def log_exception(exception, job, logger=logger):
             logger.error(
-                "Não foi possível exportar documento '%s': '%s'.",
+                "Não foi possível processar documento '%s': '%s'.",
                 job["pid"],
                 exception,
             )

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -97,6 +97,10 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
     def get_request(self) -> dict:
         return self.index_exporter.get_request
 
+    @property
+    def delete_request(self) -> dict:
+        return self.index_exporter.delete_request
+
     def put_request(self, data: dict) -> dict:
         return self.index_exporter.put_request(data)
 

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -207,6 +207,20 @@ class PutDOAJExporterXyloseArticleTest(DOAJExporterXyloseArticleTest):
         )
 
 
+class DeleteDOAJExporterXyloseArticleTest(DOAJExporterXyloseArticleTest):
+    def test_crud_article_url(self):
+        self.assertEqual(
+            config.get("DOAJ_API_URL") + "articles/" + self.article.data["doaj_id"],
+            self.doaj_document.crud_article_url,
+        )
+
+    def test_delete_request(self):
+        expected = { "params": { "api_key": config.get("DOAJ_API_KEY") } }
+        self.assertEqual(
+            expected, self.doaj_document.delete_request
+        )
+
+
 @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
 class DOAJExporterXyloseArticleExceptionsTestMixin:
     @mock.patch.dict("os.environ", {"DOAJ_API_URL": ""})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -667,7 +667,7 @@ class ProcessExtractedDocumentsTestMixin:
                 pids_by_collection={"scl": ["S0100-19651998000200001"]},
             )
             mk_logger_error.assert_called_once_with(
-                "Não foi possível exportar documento '%s': '%s'.",
+                "Não foi possível processar documento '%s': '%s'.",
                 "S0100-19651998000200001",
                 exc
             )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1195,3 +1195,9 @@ class DOAJGetMainExporterTest(MainExporterTestMixin, TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.output_path)
+
+
+class DOAJDeleteMainExporterTest(MainExporterTestMixin, TestCase):
+    index = "doaj"
+    index_command = "delete"
+    output_path = pathlib.Path("output.log")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -494,24 +494,26 @@ class ProcessDocumentTestMixin:
         )
 
     @mock.patch("exporter.main.XyloseArticleExporterAdapter", autospec=True)
-    def test_calls_XyloseArticleExporterAdapter_command_function(
+    def test_returns_XyloseArticleExporterAdapter_command_function(
         self, MockXyloseArticleExporterAdapter
     ):
         document = mock.create_autospec(
             spec=scielodocument.Article, data={"id": "document-1234"}
         )
         mk_document = mock.Mock(return_value=document)
-        mk_command_function = mock.Mock(return_value={})
+        mk_command_function = mock.Mock(
+            return_value={"id": "doaj-id-1234", "status": "OK"}
+        )
         MockXyloseArticleExporterAdapter.return_value.command_function = \
             mk_command_function
-        process_document(
+        ret = process_document(
             mk_document,
             index=self.index,
             index_command=self.index_command,
             collection="scl",
             pid="S0100-19651998000200002",
         )
-        mk_command_function.assert_called_once()
+        self.assertEqual(ret, {"id": "doaj-id-1234", "status": "OK"})
 
 
 class ExportDocumentTest(ProcessDocumentTestMixin, TestCase):
@@ -651,7 +653,7 @@ class UpdateExtractedDocumentsTest(ProcessExtractedDocumentsTestMixin, TestCase)
         fake_exported_docs = [
             {
                 "index_id": f"doaj-{pid}",
-                "status": "OK",
+                "status": "UPDATED",
                 "pid": pid,
             }
             for pid in fake_pids


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona funcionalidade de deleção de artigos implementando método HTTP DELETE do CRUD do DOAJ. Em caso de sucesso, o resultado será salvo no argumento `--output`.

#### Onde a revisão poderia começar?
Commit 7c885e3.

#### Como este poderia ser testado manualmente?
1. Instale localmente o exportador: `pip install --editable .`
2. Configure variável de ambiente `DOAJ_API_KEY`com a API KEY do DOAJ
3. Executar o exportador com o PID de um documento: `scielo-export --output <caminho para arquivo de saída> doaj delete --collection <acrônimo da coleção> --pid <PID de artigo>`
4. A aplicação não deve ser interrompida por qualquer exceção HTTP
5. Em caso de sucesso, o resultado deverá estar salvo no arquivo ou diretório cujo caminho foi passado no parâmetro `--output`.

#### Algum cenário de contexto que queira dar?
Conforme relatado em PR anterior, nem todos os artigos da fonte tem o ID do DOAJ e, nestes casos, não será possível efetuar a deleção.

### Screenshots
N/A.

#### Quais são tickets relevantes?
.

### Referências
.
