### PR TITLE
Adiciona deleção de documentos em lote

### DIFF
--- a/exporter/__init__.py
+++ b/exporter/__init__.py
@@ -1,11 +1,17 @@
 import sys
 import logging
 
-from .main import AMClient, process_extracted_documents, main_exporter
+from .main import (
+    AMClient,
+    process_extracted_documents,
+    process_documents_in_bulk,
+    main_exporter,
+)
 
 __all__ = [
     "AMClient",
-    "extract_and_export_documents",
+    "process_extracted_documents",
+    "process_documents_in_bulk",
 ]
 
 

--- a/exporter/__init__.py
+++ b/exporter/__init__.py
@@ -1,7 +1,7 @@
 import sys
 import logging
 
-from .main import AMClient, extract_and_export_documents, main_exporter
+from .main import AMClient, process_extracted_documents, main_exporter
 
 __all__ = [
     "AMClient",

--- a/exporter/config.py
+++ b/exporter/config.py
@@ -3,6 +3,7 @@ import sys
 
 _default = dict(
     DOAJ_API_URL="https://doaj.org/api/",
+    EXPORT_RUN_RETRIES=3,
 )
 
 def get(var_name: str):

--- a/exporter/config.py
+++ b/exporter/config.py
@@ -1,0 +1,9 @@
+import os
+import sys
+
+_default = dict(
+    DOAJ_API_URL="https://doaj.org/api/",
+)
+
+def get(var_name: str):
+    return os.environ.get(var_name, _default.get(var_name, ""))

--- a/exporter/config.py
+++ b/exporter/config.py
@@ -1,10 +1,18 @@
 import os
 import sys
 
+
+INITIAL_LOG_CONFIG = {
+    "format": "%(asctime)s %(levelname)-5.5s [%(name)s] %(message)s",
+    "filename": "exporter.log",
+}
+
+
 _default = dict(
     DOAJ_API_URL="https://doaj.org/api/",
     EXPORT_RUN_RETRIES=3,
 )
+
 
 def get(var_name: str):
     return os.environ.get(var_name, _default.get(var_name, ""))

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -166,10 +166,8 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
 
     def _add_bibjson_keywords(self, article: scielodocument.Article):
         keywords = article.keywords()
-        if keywords:
-            self._data["bibjson"].setdefault("keywords", [])
-            for keywords_to_send in keywords.values():
-                self._data["bibjson"]["keywords"] += keywords_to_send
+        if keywords and keywords.get(article.original_language()):
+            self._data["bibjson"]["keywords"] = keywords[article.original_language()]
 
     def _add_bibjson_link(self, article: scielodocument.Article):
         MIME_TYPE = {

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -51,6 +51,13 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
     def bibjson_title(self) -> str:
         return self._data["bibjson"]["title"]
 
+    @property
+    def post_request(self):
+        return {
+            "api_key": config.get("DOAJ_API_KEY"),
+            "article_json": self._data
+        }
+
     def add_bibjson_author(self, article: scielodocument.Article):
         if not article.authors:
             raise DOAJExporterXyloseArticleNoAuthorsException()
@@ -97,5 +104,4 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
         self._data["bibjson"]["title"] = title
 
     def export(self):
-        # Send request
         pass

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -78,6 +78,12 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
             "params": {"api_key": config.get("DOAJ_API_KEY")},
         }
 
+    @property
+    def delete_request(self) -> dict:
+        return {
+            "params": {"api_key": config.get("DOAJ_API_KEY")},
+        }
+
     def put_request(self, data: dict) -> dict:
         self._data = data
         self._data["last_updated"] = self._now

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -69,6 +69,10 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
             return url
 
     @property
+    def params_request(self) -> dict:
+        return {"api_key": config.get("DOAJ_API_KEY")}
+
+    @property
     def post_request(self) -> dict:
         self._data["created_date"] = self._data["last_updated"] = self._now
         self._data.setdefault("bibjson", {})
@@ -79,22 +83,7 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
         self._set_bibjson_keywords()
         self._set_bibjson_link()
         self._set_bibjson_title()
-        return {
-            "params": {"api_key": config.get("DOAJ_API_KEY")},
-            "json": self._data
-        }
-
-    @property
-    def get_request(self) -> dict:
-        return {
-            "params": {"api_key": config.get("DOAJ_API_KEY")},
-        }
-
-    @property
-    def delete_request(self) -> dict:
-        return {
-            "params": {"api_key": config.get("DOAJ_API_KEY")},
-        }
+        return self._data
 
     def put_request(self, data: dict) -> dict:
         self._data = data
@@ -107,10 +96,7 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
         self._set_bibjson_keywords()
         self._set_bibjson_link()
         self._set_bibjson_title()
-        return {
-            "params": {"api_key": config.get("DOAJ_API_KEY")},
-            "json": self._data
-        }
+        return self._data
 
     def post_response(self, response: dict) -> dict:
         return {

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -47,6 +47,17 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
         self.bulk_articles_url = f"{self._api_url}bulk/articles"
 
     @property
+    def id(self):
+        try:
+            id = self._data["id"]
+        except KeyError:
+            raise DOAJExporterXyloseArticleNoRequestData(
+                "No DOAJ ID for article"
+            ) from None
+        else:
+            return id
+
+    @property
     def crud_article_url(self):
         try:
             url = f'{self._api_url}articles/{self._data["id"]}'

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -30,6 +30,7 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
         self.add_bibjson_author(article)
         self.add_bibjson_identifier(article)
         self.add_bibjson_journal(article)
+        self.add_bibjson_keywords(article)
         self.add_bibjson_title(article)
 
     def _set_api_config(self):
@@ -60,6 +61,10 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
     @property
     def bibjson_journal(self) -> str:
         return self._data["bibjson"]["journal"]
+
+    @property
+    def bibjson_keywords(self) -> str:
+        return self._data["bibjson"].get("keywords")
 
     @property
     def bibjson_title(self) -> str:
@@ -134,6 +139,13 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
         _set_journal_field(journal, article, "title", "title", required=True)
 
         self._data["bibjson"]["journal"] = journal
+
+    def add_bibjson_keywords(self, article: scielodocument.Article):
+        keywords = article.keywords()
+        if keywords:
+            self._data["bibjson"].setdefault("keywords", [])
+            for keywords_to_send in keywords.values():
+                self._data["bibjson"]["keywords"] += keywords_to_send
 
     def add_bibjson_title(self, article: scielodocument.Article):
         title = article.original_title()

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -27,11 +27,11 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
         self._data = {}
         self._data["created_date"] = self._data["last_updated"] = now
         self._data.setdefault("bibjson", {})
-        self.add_bibjson_author(article)
         self.add_bibjson_identifier(article)
-        self.add_bibjson_journal(article)
-        self.add_bibjson_keywords(article)
-        self.add_bibjson_title(article)
+        self._add_bibjson_author(article)
+        self._add_bibjson_journal(article)
+        self._add_bibjson_keywords(article)
+        self._add_bibjson_title(article)
 
     def _set_api_config(self):
         for attr, envvar in [("_api_url", "DOAJ_API_URL"), ("_api_key", "DOAJ_API_KEY")]:
@@ -86,7 +86,7 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
     def error_response(self, response: dict) -> str:
         return response.get("error", "")
 
-    def add_bibjson_author(self, article: scielodocument.Article):
+    def _add_bibjson_author(self, article: scielodocument.Article):
         if not article.authors:
             raise DOAJExporterXyloseArticleNoAuthorsException()
 
@@ -114,7 +114,7 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
                 {"id": article.doi, "type": "doi"}
             )
 
-    def add_bibjson_journal(self, article: scielodocument.Article):
+    def _add_bibjson_journal(self, article: scielodocument.Article):
         journal = {}
 
         def _set_journal_field(journal, article, field, field_to_set, required=False):
@@ -140,14 +140,14 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
 
         self._data["bibjson"]["journal"] = journal
 
-    def add_bibjson_keywords(self, article: scielodocument.Article):
+    def _add_bibjson_keywords(self, article: scielodocument.Article):
         keywords = article.keywords()
         if keywords:
             self._data["bibjson"].setdefault("keywords", [])
             for keywords_to_send in keywords.values():
                 self._data["bibjson"]["keywords"] += keywords_to_send
 
-    def add_bibjson_title(self, article: scielodocument.Article):
+    def _add_bibjson_title(self, article: scielodocument.Article):
         title = article.original_title()
         if (
             not title and

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -68,8 +68,8 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
     @property
     def post_request(self) -> dict:
         return {
-            "api_key": config.get("DOAJ_API_KEY"),
-            "article_json": self._data
+            "params": {"api_key": config.get("DOAJ_API_KEY")},
+            "json": self._data
         }
 
     def post_response(self, response: dict) -> dict:

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -218,3 +218,6 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
 
     def export(self):
         pass
+
+    def update(self):
+        pass

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -64,6 +64,9 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
             "status": response.get("status"),
         }
 
+    def error_response(self, response: dict) -> str:
+        return response.get("error", "")
+
     def add_bibjson_author(self, article: scielodocument.Article):
         if not article.authors:
             raise DOAJExporterXyloseArticleNoAuthorsException()

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -70,7 +70,9 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
 
         self._data["bibjson"].setdefault("author", [])
         for author in article.authors:
-            author_name = [author.get('given_names', ''), author.get('surname', '')]
+            author_name = " ".join(
+                [author.get('given_names', ''), author.get('surname', '')]
+            )
             self._data["bibjson"]["author"].append({"name": author_name})
 
     def add_bibjson_identifier(self, article: scielodocument.Article):

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -79,7 +79,20 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
         }
 
     def put_request(self, data: dict) -> dict:
-        pass
+        self._data = data
+        self._data["last_updated"] = self._now
+        self._data.setdefault("bibjson", {})
+        self._set_bibjson_abstract()
+        self._set_bibjson_author()
+        self._set_bibjson_identifier()
+        self._set_bibjson_journal()
+        self._set_bibjson_keywords()
+        self._set_bibjson_link()
+        self._set_bibjson_title()
+        return {
+            "params": {"api_key": config.get("DOAJ_API_KEY")},
+            "json": self._data
+        }
 
     def post_response(self, response: dict) -> dict:
         return {

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -44,6 +44,7 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
 
         self.crud_article_put_url = f"{self._api_url}articles"
         self.search_journal_url = f"{self._api_url}search/journals/"
+        self.bulk_articles_url = f"{self._api_url}bulk/articles"
 
     @property
     def crud_article_url(self):

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -52,10 +52,16 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
         return self._data["bibjson"]["title"]
 
     @property
-    def post_request(self):
+    def post_request(self) -> dict:
         return {
             "api_key": config.get("DOAJ_API_KEY"),
             "article_json": self._data
+        }
+
+    def post_response(self, response: dict) -> dict:
+        return {
+            "index_id": response.get("id"),
+            "status": response.get("status"),
         }
 
     def add_bibjson_author(self, article: scielodocument.Article):

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -106,6 +106,12 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
             "json": self._data
         }
 
+    @property
+    def get_request(self) -> dict:
+        return {
+            "params": {"api_key": config.get("DOAJ_API_KEY")},
+        }
+
     def post_response(self, response: dict) -> dict:
         return {
             "index_id": response.get("id"),

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -198,13 +198,6 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
 
     def _add_bibjson_title(self, article: scielodocument.Article):
         title = article.original_title()
-        if (
-            not title and
-            article.translated_titles() and
-            len(article.translated_titles()) != 0
-        ):
-            item = [(k, v) for k, v in article.translated_titles().items()][0]
-            title = item[1]
 
         if not title:
             section_code = article.section_code

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -29,18 +29,11 @@ class DOAJExporterXyloseArticleNoDOINorlink(Exception):
 class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
     def __init__(self, article: scielodocument.Article, now: callable = utils.utcnow()):
         self._set_api_config()
+        self._article = article
+        self._now = now
         self._data = {}
         if article.data.get("doaj_id"):
             self._data["id"] = article.data["doaj_id"]
-        self._data["created_date"] = self._data["last_updated"] = now
-        self._data.setdefault("bibjson", {})
-        self._add_bibjson_abstract(article)
-        self._add_bibjson_author(article)
-        self._add_bibjson_identifier(article)
-        self._add_bibjson_journal(article)
-        self._add_bibjson_keywords(article)
-        self._add_bibjson_link(article)
-        self._add_bibjson_title(article)
 
     def _set_api_config(self):
         for attr, envvar in [("_api_url", "DOAJ_API_URL"), ("_api_key", "DOAJ_API_KEY")]:
@@ -101,6 +94,15 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
 
     @property
     def post_request(self) -> dict:
+        self._data["created_date"] = self._data["last_updated"] = self._now
+        self._data.setdefault("bibjson", {})
+        self._set_bibjson_abstract()
+        self._set_bibjson_author()
+        self._set_bibjson_identifier()
+        self._set_bibjson_journal()
+        self._set_bibjson_keywords()
+        self._set_bibjson_link()
+        self._set_bibjson_title()
         return {
             "params": {"api_key": config.get("DOAJ_API_KEY")},
             "json": self._data
@@ -124,25 +126,25 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
     def error_response(self, response: dict) -> str:
         return response.get("error", "")
 
-    def _add_bibjson_abstract(self, article: scielodocument.Article):
-        abstract = article.original_abstract()
+    def _set_bibjson_abstract(self):
+        abstract = self._article.original_abstract()
         if abstract:
             self._data["bibjson"]["abstract"] = abstract
 
-    def _add_bibjson_author(self, article: scielodocument.Article):
-        if not article.authors:
+    def _set_bibjson_author(self):
+        if not self._article.authors:
             raise DOAJExporterXyloseArticleNoAuthorsException()
 
         self._data["bibjson"].setdefault("author", [])
-        for author in article.authors:
+        for author in self._article.authors:
             author_name = " ".join(
                 [author.get('given_names', ''), author.get('surname', '')]
             )
             self._data["bibjson"]["author"].append({"name": author_name})
 
-    def _get_registered_journal_issn(self, article: scielodocument.Article):
+    def _get_registered_journal_issn(self):
         for journal_attr in ["electronic_issn", "print_issn"]:
-            issn = getattr(article.journal, journal_attr)
+            issn = getattr(self._article.journal, journal_attr)
             if not issn:
                 continue
 
@@ -161,53 +163,53 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
             raise DOAJExporterXyloseArticleNoISSNException()
 
 
-    def _add_bibjson_identifier(self, article: scielodocument.Article):
-        issn, issn_type = self._get_registered_journal_issn(article)
+    def _set_bibjson_identifier(self):
+        issn, issn_type = self._get_registered_journal_issn()
         self._data["bibjson"]["identifier"] = [{"id": issn, "type": issn_type}]
 
-        if article.doi:
+        if self._article.doi:
             self._data["bibjson"]["identifier"].append(
-                {"id": article.doi, "type": "doi"}
+                {"id": self._article.doi, "type": "doi"}
             )
 
-    def _add_bibjson_journal(self, article: scielodocument.Article):
+    def _set_bibjson_journal(self):
         journal = {}
 
         def _set_journal_field(journal, article, field, field_to_set, required=False):
-            journal_field = getattr(article.journal, field)
+            journal_field = getattr(self._article.journal, field)
             if journal_field:
                 journal[field_to_set] = journal_field
             elif not journal_field and required:
                 raise DOAJExporterXyloseArticleNoJournalRequiredFields()
 
 
-        publisher_country = article.journal.publisher_country
+        publisher_country = self._article.journal.publisher_country
         if not publisher_country:
             raise DOAJExporterXyloseArticleNoJournalRequiredFields()
         else:
             country_code, __ = publisher_country
             journal["country"] = country_code
 
-        _set_journal_field(journal, article, "languages", "language", required=True)
+        _set_journal_field(journal, self._article, "languages", "language", required=True)
         _set_journal_field(
-            journal, article, "publisher_name", "publisher", required=True
+            journal, self._article, "publisher_name", "publisher", required=True
         )
-        _set_journal_field(journal, article, "title", "title", required=True)
+        _set_journal_field(journal, self._article, "title", "title", required=True)
 
         self._data["bibjson"]["journal"] = journal
 
-    def _add_bibjson_keywords(self, article: scielodocument.Article):
-        keywords = article.keywords()
-        if keywords and keywords.get(article.original_language()):
-            self._data["bibjson"]["keywords"] = keywords[article.original_language()]
+    def _set_bibjson_keywords(self):
+        keywords = self._article.keywords()
+        if keywords and keywords.get(self._article.original_language()):
+            self._data["bibjson"]["keywords"] = keywords[self._article.original_language()]
 
-    def _add_bibjson_link(self, article: scielodocument.Article):
+    def _set_bibjson_link(self):
         MIME_TYPE = {
             "html": "text/html",
             "pdf": "application/pdf",
         }
 
-        fulltexts = article.fulltexts()
+        fulltexts = self._article.fulltexts()
         if fulltexts:
             self._data["bibjson"].setdefault("link", [])
             for content_type, links in fulltexts.items():
@@ -221,18 +223,18 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
                             }
                         )
 
-        if not (self._data["bibjson"].get("link") or article.doi):
+        if not (self._data["bibjson"].get("link") or self._article.doi):
             raise DOAJExporterXyloseArticleNoDOINorlink(
                 "Documento não possui DOI ou links para texto completo"
             )
 
-    def _add_bibjson_title(self, article: scielodocument.Article):
-        title = article.original_title()
+    def _set_bibjson_title(self):
+        title = self._article.original_title()
 
         if not title:
-            section_code = article.section_code
-            original_lang = article.original_language()
-            title = article.issue.sections.get(section_code, {}).get(
+            section_code = self._article.section_code
+            original_lang = self._article.original_language()
+            title = self._article.issue.sections.get(section_code, {}).get(
                 original_lang, "Documento sem título"
             )
 

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -112,6 +112,9 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
             "params": {"api_key": config.get("DOAJ_API_KEY")},
         }
 
+    def put_request(self, data: dict) -> dict:
+        pass
+
     def post_response(self, response: dict) -> dict:
         return {
             "index_id": response.get("id"),

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -216,8 +216,5 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
 
         self._data["bibjson"]["title"] = title
 
-    def export(self):
-        pass
-
-    def update(self):
+    def command_function(self):
         pass

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -32,6 +32,7 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
         self._data = {}
         self._data["created_date"] = self._data["last_updated"] = now
         self._data.setdefault("bibjson", {})
+        self._add_bibjson_abstract(article)
         self._add_bibjson_author(article)
         self._add_bibjson_identifier(article)
         self._add_bibjson_journal(article)
@@ -56,6 +57,10 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
     @property
     def last_updated(self) -> typing.List[dict]:
         return self._data["last_updated"]
+
+    @property
+    def bibjson_abstract(self) -> typing.List[dict]:
+        return self._data["bibjson"].get("abstract")
 
     @property
     def bibjson_author(self) -> typing.List[dict]:
@@ -96,6 +101,11 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
 
     def error_response(self, response: dict) -> str:
         return response.get("error", "")
+
+    def _add_bibjson_abstract(self, article: scielodocument.Article):
+        abstract = article.original_abstract()
+        if abstract:
+            self._data["bibjson"]["abstract"] = abstract
 
     def _add_bibjson_author(self, article: scielodocument.Article):
         if not article.authors:

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -2,7 +2,7 @@ import typing
 
 from xylose import scielodocument
 
-from exporter import interfaces, config
+from exporter import interfaces, config, utils
 
 
 class DOAJExporterXyloseArticleNoRequestData(Exception):
@@ -22,9 +22,10 @@ class DOAJExporterXyloseArticleNoISSNException(Exception):
 
 
 class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
-    def __init__(self, article: scielodocument.Article):
+    def __init__(self, article: scielodocument.Article, now: callable = utils.utcnow()):
         self._set_api_config()
         self._data = {}
+        self._data["created_date"] = self._data["last_updated"] = now
         self._data.setdefault("bibjson", {})
         self.add_bibjson_author(article)
         self.add_bibjson_identifier(article)
@@ -39,6 +40,14 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
             setattr(self, attr, config_var)
 
         self.crud_article_url = f"{self._api_url}articles"
+
+    @property
+    def created_date(self) -> typing.List[dict]:
+        return self._data["created_date"]
+
+    @property
+    def last_updated(self) -> typing.List[dict]:
+        return self._data["last_updated"]
 
     @property
     def bibjson_author(self) -> typing.List[dict]:

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -57,42 +57,6 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
             return url
 
     @property
-    def created_date(self) -> typing.List[dict]:
-        return self._data["created_date"]
-
-    @property
-    def last_updated(self) -> typing.List[dict]:
-        return self._data["last_updated"]
-
-    @property
-    def bibjson_abstract(self) -> typing.List[dict]:
-        return self._data["bibjson"].get("abstract")
-
-    @property
-    def bibjson_author(self) -> typing.List[dict]:
-        return self._data["bibjson"]["author"]
-
-    @property
-    def bibjson_identifier(self) -> typing.List[dict]:
-        return self._data["bibjson"]["identifier"]
-
-    @property
-    def bibjson_journal(self) -> str:
-        return self._data["bibjson"]["journal"]
-
-    @property
-    def bibjson_keywords(self) -> str:
-        return self._data["bibjson"].get("keywords")
-
-    @property
-    def bibjson_link(self) -> str:
-        return self._data["bibjson"]["link"]
-
-    @property
-    def bibjson_title(self) -> str:
-        return self._data["bibjson"]["title"]
-
-    @property
     def post_request(self) -> dict:
         self._data["created_date"] = self._data["last_updated"] = self._now
         self._data.setdefault("bibjson", {})

--- a/exporter/doaj.py
+++ b/exporter/doaj.py
@@ -33,6 +33,10 @@ class DOAJExporterXyloseArticle(interfaces.IndexExporterInterface):
     def bibjson_title(self) -> str:
         return self._data["bibjson"]["title"]
 
+    @property
+    def bibjson_title(self) -> str:
+        return self._data["bibjson"]["title"]
+
     def add_bibjson_author(self, article: scielodocument.Article):
         if not article.authors:
             raise DOAJExporterXyloseArticleNoAuthorsException()

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -11,6 +11,10 @@ class IndexExporterInterface(ABC):
         pass
 
     @abstractmethod
+    def delete_request(self) -> dict:
+        pass
+
+    @abstractmethod
     def put_request(self, data: dict) -> dict:
         pass
 

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -17,3 +17,7 @@ class IndexExporterInterface(ABC):
     @abstractmethod
     def export(self):
         pass
+
+    @abstractmethod
+    def update(self):
+        pass

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -3,15 +3,11 @@ from abc import ABC, abstractmethod
 
 class IndexExporterInterface(ABC):
     @abstractmethod
+    def params_request(self) -> dict:
+        pass
+
+    @abstractmethod
     def post_request(self) -> dict:
-        pass
-
-    @abstractmethod
-    def get_request(self) -> dict:
-        pass
-
-    @abstractmethod
-    def delete_request(self) -> dict:
         pass
 
     @abstractmethod

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -11,6 +11,10 @@ class IndexExporterInterface(ABC):
         pass
 
     @abstractmethod
+    def put_request(self, data: dict) -> dict:
+        pass
+
+    @abstractmethod
     def post_response(self, response: dict) -> dict:
         pass
 

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -3,5 +3,9 @@ from abc import ABC, abstractmethod
 
 class IndexExporterInterface(ABC):
     @abstractmethod
+    def post_request(self):
+        pass
+
+    @abstractmethod
     def export(self):
         pass

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -3,7 +3,11 @@ from abc import ABC, abstractmethod
 
 class IndexExporterInterface(ABC):
     @abstractmethod
-    def post_request(self):
+    def post_request(self) -> dict:
+        pass
+
+    @abstractmethod
+    def post_response(self, response: dict) -> dict:
         pass
 
     @abstractmethod

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -11,5 +11,9 @@ class IndexExporterInterface(ABC):
         pass
 
     @abstractmethod
+    def error_response(self, response: dict) -> str:
+        pass
+
+    @abstractmethod
     def export(self):
         pass

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -15,9 +15,5 @@ class IndexExporterInterface(ABC):
         pass
 
     @abstractmethod
-    def export(self):
-        pass
-
-    @abstractmethod
-    def update(self):
+    def command_function(self):
         pass

--- a/exporter/interfaces.py
+++ b/exporter/interfaces.py
@@ -7,6 +7,10 @@ class IndexExporterInterface(ABC):
         pass
 
     @abstractmethod
+    def get_request(self) -> dict:
+        pass
+
+    @abstractmethod
     def post_response(self, response: dict) -> dict:
         pass
 

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -92,16 +92,12 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
         self._pid = article.data.get("code", "")
 
     @property
+    def params_request(self) -> dict:
+        return self.index_exporter.params_request
+
+    @property
     def post_request(self) -> dict:
         return self.index_exporter.post_request
-
-    @property
-    def get_request(self) -> dict:
-        return self.index_exporter.get_request
-
-    @property
-    def delete_request(self) -> dict:
-        return self.index_exporter.delete_request
 
     def put_request(self, data: dict) -> dict:
         return self.index_exporter.put_request(data)
@@ -125,7 +121,10 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
 
     def _export(self):
         resp = self._send_http_request(
-            requests.post, self.index_exporter.crud_article_put_url, **self.post_request
+            requests.post,
+            self.index_exporter.crud_article_put_url,
+            self.params_request,
+            self.post_request,
         )
         try:
             resp.raise_for_status()
@@ -141,7 +140,9 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
 
     def _update(self):
         get_resp = self._send_http_request(
-            requests.get, self.index_exporter.crud_article_url, **self.get_request,
+            requests.get,
+            self.index_exporter.crud_article_url,
+            self.params_request,
         )
         try:
             get_resp.raise_for_status()
@@ -154,7 +155,8 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
             put_resp = self._send_http_request(
                 requests.put,
                 self.index_exporter.crud_article_url,
-                **put_req,
+                self.params_request,
+                put_req,
             )
             try:
                 put_resp.raise_for_status()
@@ -169,7 +171,9 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
 
     def _get(self):
         get_resp = self._send_http_request(
-            requests.get, self.index_exporter.crud_article_url, **self.get_request,
+            requests.get,
+            self.index_exporter.crud_article_url,
+            self.params_request,
         )
         try:
             get_resp.raise_for_status()
@@ -184,7 +188,9 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
 
     def _delete(self):
         delete_resp = self._send_http_request(
-            requests.delete, self.index_exporter.crud_article_url, **self.delete_request,
+            requests.delete,
+            self.index_exporter.crud_article_url,
+            self.params_request,
         )
         try:
             delete_resp.raise_for_status()

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -392,6 +392,10 @@ def main_exporter(sargs):
         "get", help="Obtém documentos", parents=[articlemeta_parser(sargs)],
     )
 
+    doaj_export_subparsers.add_parser(
+        "delete", help="Deleta documentos", parents=[articlemeta_parser(sargs)],
+    )
+
     args = parser.parse_args(sargs)
 
     if not (args.from_date or args.until_date or args.pid or args.pids):

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -77,7 +77,7 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
     )
     def _http_post_articles(self):
         return requests.post(
-            self.index_exporter.crud_article_url, data=self.post_request
+            url=self.index_exporter.crud_article_url, **self.post_request
         )
 
     def export(self):

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -55,10 +55,14 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
         else:
             raise InvalidIndexExporter()
         self.index = index
+        self._pid = article.data.get("code", "")
 
     @property
-    def post_request(self):
+    def post_request(self) -> dict:
         return self.index_exporter.post_request
+
+    def post_response(self, response: dict) -> dict:
+        return self.index_exporter.post_response(response)
 
     @tenacity.retry(
         wait=tenacity.wait_exponential(),
@@ -82,7 +86,9 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
                 f"Erro na exportação ao {self.index}: " + str(exc)
             )
         else:
-            return resp
+            export_result = self.post_response(resp.json())
+            export_result["pid"] = self._pid
+            return export_result
 
 
 class PoisonPill:

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -292,10 +292,15 @@ def main_exporter(sargs):
         help="Caminho para arquivo de resultado da exportação",
     )
 
-    subparsers = parser.add_subparsers(title="Index", metavar="", dest="index")
+    subparsers = parser.add_subparsers(title="Index", dest="index", required=True)
 
-    doaj_parser = subparsers.add_parser(
-        "doaj", help="Base de indexação DOAJ", parents=[articlemeta_parser(sargs)],
+    doaj_parser = subparsers.add_parser("doaj", help="Base de indexação DOAJ")
+    doaj_export_subparsers = doaj_parser.add_subparsers(
+        title="DOAJ Command", dest="doaj_command", required=True,
+    )
+
+    doaj_export_subparsers.add_parser(
+        "export", help="Exporta documentos", parents=[articlemeta_parser(sargs)],
     )
 
     args = parser.parse_args(sargs)

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -48,6 +48,10 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
         else:
             raise InvalidIndexExporter()
 
+    @property
+    def post_request(self):
+        return self.index_exporter.post_request
+
     def export(self):
         request = self.index_exporter.export()
 

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -130,7 +130,15 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
             return export_result
 
     def _update(self):
-        pass
+        resp = self._send_http_request(
+            requests.get, self.index_exporter.crud_article_url, **self.get_request,
+        )
+        try:
+            resp.raise_for_status()
+        except HTTPError as exc:
+            error_response = self.error_response(resp.json())
+            exc_msg = f"Erro na consulta ao {self.index}: {exc}. {error_response}"
+            raise IndexExporterHTTPError(exc_msg)
 
     def command_function(self):
         return self._command_function()

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -91,6 +91,10 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
     def post_request(self) -> dict:
         return self.index_exporter.post_request
 
+    @property
+    def get_request(self) -> dict:
+        return self.index_exporter.get_request
+
     def post_response(self, response: dict) -> dict:
         return self.index_exporter.post_response(response)
 

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -180,23 +180,15 @@ def export_document(
 
 
 def extract_and_export_documents(
+    get_document:callable,
     index:str,
     collection:str,
     output_path:str,
     pids:typing.List[str],
-    connection:str=None,
-    domain:str=None,
 ) -> None:
-    params = {}
-    if connection:
-        params["connection"] = connection
-    if domain:
-        params["domain"] = domain
-
-    am_client = AMClient(**params) if params else AMClient()
 
     jobs = [
-        {"get_document": am_client.document, "index": index, "collection": collection, "pid": pid}
+        {"get_document": get_document, "index": index, "collection": collection, "pid": pid}
         for pid in pids
     ]
 
@@ -324,6 +316,15 @@ def main_exporter(sargs):
     params = {
         "index": args.index, "collection": args.collection, "output_path": args.output
     }
+    am_client_params = {}
+    if args.connection:
+        am_client_params["connection"] = args.connection
+    if args.domain:
+        am_client_params["domain"] = args.domain
+
+    am_client = AMClient(**am_client_params) if am_client_params else AMClient()
+    params["get_document"] = am_client.document
+
     if args.pid:
         params["pids"] = [args.pid]
     elif args.pids:

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -114,6 +114,9 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
             export_result["pid"] = self._pid
             return export_result
 
+    def update(self):
+        pass
+
 
 class PoisonPill:
     def __init__(self):

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -146,6 +146,14 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
                 self.index_exporter.crud_article_url,
                 **put_req,
             )
+            try:
+                put_resp.raise_for_status()
+            except HTTPError as exc:
+                error_response = self.error_response(put_resp.json())
+                exc_msg = f"Erro ao atualizar o {self.index}: {exc}. {error_response}"
+                raise IndexExporterHTTPError(exc_msg)
+            else:
+                return { "pid": self._pid, "status": "OK" }
 
     def command_function(self):
         return self._command_function()

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -200,7 +200,7 @@ class JobExecutor:
                     except Exception as exc:
                         self.exception_callback(exc, job)
                     else:
-                        self.success_callback(result)
+                        self.success_callback(result, job)
                     finally:
                         self.update_bar()
             except KeyboardInterrupt:
@@ -254,10 +254,16 @@ def process_extracted_documents(
         def update_bar(pbar=pbar):
             pbar.update(1)
 
-        def write_result(result, path:pathlib.Path=output_path):
-            logger.debug('Gravando resultado em arquivo %s: "%s"', path, result)
-            with path.open("a", encoding="utf-8") as fp:
-                fp.write(json.dumps(result) + "\n")
+        def write_result(result, job, path:pathlib.Path=output_path):
+            if path.is_dir():
+                file_path = path / f'{job["pid"]}.json'
+                logger.debug('Gravando resultado em arquivo %s: "%s"', file_path)
+                with file_path.open("w", encoding="utf-8") as fp:
+                    json.dump(result, fp)
+            else:
+                logger.debug('Gravando resultado em arquivo %s: "%s"', path, result)
+                with path.open("a", encoding="utf-8") as fp:
+                    fp.write(json.dumps(result) + "\n")
 
         def log_exception(exception, job, logger=logger):
             logger.error(

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -305,7 +305,7 @@ def process_extracted_documents(
 
         def log_exception(exception, job, logger=logger):
             logger.error(
-                "Não foi possível exportar documento '%s': '%s'.",
+                "Não foi possível processar documento '%s': '%s'.",
                 job["pid"],
                 exception,
             )

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -95,6 +95,9 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
     def get_request(self) -> dict:
         return self.index_exporter.get_request
 
+    def put_request(self, data: dict) -> dict:
+        pass
+
     def post_response(self, response: dict) -> dict:
         return self.index_exporter.post_response(response)
 

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -97,6 +97,10 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
     def get_request(self) -> dict:
         return self.index_exporter.get_request
 
+    @property
+    def delete_request(self) -> dict:
+        return self.index_exporter.delete_request
+
     def put_request(self, data: dict) -> dict:
         return self.index_exporter.put_request(data)
 

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -140,9 +140,9 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
         try:
             get_resp.raise_for_status()
         except HTTPError as exc:
-            error_response = self.error_response(get_resp.json())
-            exc_msg = f"Erro na consulta ao {self.index}: {exc}. {error_response}"
-            raise IndexExporterHTTPError(exc_msg)
+            raise IndexExporterHTTPError(
+                f"Erro na consulta ao {self.index}: {exc}."
+            )
         else:
             put_req = self.put_request(get_resp.json())
             put_resp = self._send_http_request(
@@ -168,9 +168,9 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
         try:
             get_resp.raise_for_status()
         except HTTPError as exc:
-            error_response = self.error_response(get_resp.json())
-            exc_msg = f"Erro na consulta ao {self.index}: {exc}. {error_response}"
-            raise IndexExporterHTTPError(exc_msg)
+            raise IndexExporterHTTPError(
+                f"Erro na consulta ao {self.index}: {exc}."
+            )
         else:
             get_result = get_resp.json()
             get_result["pid"] = self._pid

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -321,6 +321,16 @@ def process_extracted_documents(
     return
 
 
+def process_documents_in_bulk(
+    get_document:callable,
+    index:str,
+    index_command:str,
+    output_path:pathlib.Path,
+    pids_by_collection:typing.Dict[str, list],
+) -> None:
+    pass
+
+
 def articlemeta_parser(sargs):
     """Parser para capturar informações sobre conexão com o Article Meta"""
 
@@ -397,23 +407,24 @@ def main_exporter(sargs):
     subparsers = parser.add_subparsers(title="Index", dest="index", required=True)
 
     doaj_parser = subparsers.add_parser("doaj", help="Base de indexação DOAJ")
-    doaj_export_subparsers = doaj_parser.add_subparsers(
+    doaj_subparsers = doaj_parser.add_subparsers(
         title="DOAJ Command", dest="doaj_command", required=True,
     )
 
-    doaj_export_subparsers.add_parser(
+    doaj_export_parser = doaj_subparsers.add_parser(
         "export", help="Exporta documentos", parents=[articlemeta_parser(sargs)],
     )
+    doaj_export_parser.add_argument("--bulk", action="store_true", help="Exporta documentos em lote")
 
-    doaj_export_subparsers.add_parser(
+    doaj_subparsers.add_parser(
         "update", help="Atualiza documentos", parents=[articlemeta_parser(sargs)],
     )
 
-    doaj_export_subparsers.add_parser(
+    doaj_subparsers.add_parser(
         "get", help="Obtém documentos", parents=[articlemeta_parser(sargs)],
     )
 
-    doaj_export_subparsers.add_parser(
+    doaj_subparsers.add_parser(
         "delete", help="Deleta documentos", parents=[articlemeta_parser(sargs)],
     )
 
@@ -476,4 +487,7 @@ def main_exporter(sargs):
             params["pids_by_collection"].setdefault(doc["collection"], [])
             params["pids_by_collection"][doc["collection"]].append(doc["code"])
 
-    process_extracted_documents(**params)
+    if getattr(args, "bulk", None):
+        process_documents_in_bulk(**params)
+    else:
+        process_extracted_documents(**params)

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -179,7 +179,7 @@ def export_document(
     return article_adapter.export()
 
 
-def extract_and_export_documents(
+def process_extracted_documents(
     get_document:callable,
     index:str,
     output_path:pathlib.Path,
@@ -359,4 +359,4 @@ def main_exporter(sargs):
             params["pids_by_collection"].setdefault(doc["collection"], [])
             params["pids_by_collection"][doc["collection"]].append(doc["code"])
 
-    extract_and_export_documents(**params)
+    process_extracted_documents(**params)

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -186,7 +186,8 @@ def extract_and_export_documents(
 
         def write_result(result, path=output_path):
             output_file = pathlib.Path(path)
-            output_file.write_text(json.dumps(result) + "\n")
+            with output_file.open("a", encoding="utf-8") as fp:
+                fp.write(json.dumps(result) + "\n")
 
         def log_exception(exception, job, logger=logger):
             logger.error(

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -104,13 +104,13 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
             (requests.ConnectionError, requests.Timeout),
         ),
     )
-    def _http_post_articles(self):
-        return requests.post(
-            url=self.index_exporter.crud_article_url, **self.post_request
-        )
+    def _send_http_request(self, request_method: callable, url: str, **request: json):
+        return request_method(url=url, **request)
 
-        resp = self._http_post_articles()
     def _export(self):
+        resp = self._send_http_request(
+            requests.post, self.index_exporter.crud_article_url, **self.post_request
+        )
         try:
             resp.raise_for_status()
         except HTTPError as exc:

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -365,6 +365,10 @@ def main_exporter(sargs):
         "update", help="Atualiza documentos", parents=[articlemeta_parser(sargs)],
     )
 
+    doaj_export_subparsers.add_parser(
+        "get", help="Obtém documentos", parents=[articlemeta_parser(sargs)],
+    )
+
     args = parser.parse_args(sargs)
 
     if not (args.from_date or args.until_date or args.pid or args.pids):

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -144,8 +144,10 @@ class XyloseArticleExporterAdapter(
         try:
             resp.raise_for_status()
         except HTTPError as exc:
-            error_response = self.error_response(resp.json())
-            exc_msg = f"Erro na exportação ao {self.index}: {exc}. {error_response}"
+            error_response = ""
+            if resp.status_code == 400:
+                error_response = " " + self.error_response(resp.json())
+            exc_msg = f"Erro na exportação ao {self.index}: {exc}.{error_response}"
             raise IndexExporterHTTPError(exc_msg)
         else:
             export_result = self.post_response(resp.json())
@@ -176,8 +178,10 @@ class XyloseArticleExporterAdapter(
             try:
                 put_resp.raise_for_status()
             except HTTPError as exc:
-                error_response = self.error_response(put_resp.json())
-                exc_msg = f"Erro ao atualizar o {self.index}: {exc}. {error_response}"
+                error_response = ""
+                if put_resp.status_code == 400:
+                    error_response = " " + self.error_response(put_resp.json())
+                exc_msg = f"Erro ao atualizar o {self.index}: {exc}.{error_response}"
                 raise IndexExporterHTTPError(exc_msg)
             else:
                 update_result = { "pid": self._pid, "status": "UPDATED" }
@@ -285,8 +289,10 @@ class XyloseArticlesListExporterAdapter(
         try:
             resp.raise_for_status()
         except HTTPError as exc:
-            error_response = self.error_response(resp.json())
-            exc_msg = f"Erro na exportação ao {self.index}: {exc}. {error_response}"
+            error_response = ""
+            if resp.status_code == 400:
+                error_response = " " + self.error_response(resp.json())
+            exc_msg = f"Erro na exportação ao {self.index}: {exc}.{error_response}"
             raise IndexExporterHTTPError(exc_msg)
         else:
             export_result = self.post_response(resp.json())

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -96,7 +96,7 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
         return self.index_exporter.get_request
 
     def put_request(self, data: dict) -> dict:
-        pass
+        return self.index_exporter.put_request(data)
 
     def post_response(self, response: dict) -> dict:
         return self.index_exporter.post_response(response)
@@ -130,15 +130,22 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
             return export_result
 
     def _update(self):
-        resp = self._send_http_request(
+        get_resp = self._send_http_request(
             requests.get, self.index_exporter.crud_article_url, **self.get_request,
         )
         try:
-            resp.raise_for_status()
+            get_resp.raise_for_status()
         except HTTPError as exc:
-            error_response = self.error_response(resp.json())
+            error_response = self.error_response(get_resp.json())
             exc_msg = f"Erro na consulta ao {self.index}: {exc}. {error_response}"
             raise IndexExporterHTTPError(exc_msg)
+        else:
+            put_req = self.put_request(get_resp.json())
+            put_resp = self._send_http_request(
+                requests.put,
+                self.index_exporter.crud_article_url,
+                **put_req,
+            )
 
     def command_function(self):
         return self._command_function()

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -78,9 +78,9 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
             raise InvalidExporterInitData(f"Index informado inválido: {index}")
 
         if command == "export":
-            self.command_function = self.export
+            self._command_function = self._export
         elif command == "update":
-            self.command_function = self.update
+            self._command_function = self._update
         else:
             raise InvalidExporterInitData(f"Comando informado inválido: {command}")
 
@@ -109,8 +109,8 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
             url=self.index_exporter.crud_article_url, **self.post_request
         )
 
-    def export(self):
         resp = self._http_post_articles()
+    def _export(self):
         try:
             resp.raise_for_status()
         except HTTPError as exc:
@@ -122,8 +122,11 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
             export_result["pid"] = self._pid
             return export_result
 
-    def update(self):
+    def _update(self):
         pass
+
+    def command_function(self):
+        return self._command_function()
 
 
 class PoisonPill:

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -46,6 +46,22 @@ class AMClient:
     def document(self, collection: str, pid: str) -> scielodocument.Article:
         return self._client.document(collection=collection, code=pid)
 
+    def documents_identifiers(
+        self,
+        collection: str = None,
+        from_date: datetime = None,
+        until_date: datetime = None,
+    ) -> typing.List[dict]:
+        filter = {}
+        if collection:
+            filter["collection"] = collection
+        if from_date:
+            filter["from_date"] = from_date.strftime("%Y-%m-%d")
+        if until_date:
+            filter["until_date"] = until_date.strftime("%Y-%m-%d")
+
+        return self._client.documents_by_identifiers(only_identifiers=True, **filter)
+
 
 class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
     index_exporter: interfaces.IndexExporterInterface

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -566,7 +566,9 @@ def main_exporter(sargs):
     doaj_export_parser = doaj_subparsers.add_parser(
         "export", help="Exporta documentos", parents=[articlemeta_parser(sargs)],
     )
-    doaj_export_parser.add_argument("--bulk", action="store_true", help="Exporta documentos em lote")
+    doaj_export_parser.add_argument(
+        "--bulk", action="store_true", help="Exporta documentos em lote"
+    )
 
     doaj_subparsers.add_parser(
         "update", help="Atualiza documentos", parents=[articlemeta_parser(sargs)],
@@ -576,8 +578,11 @@ def main_exporter(sargs):
         "get", help="Obtém documentos", parents=[articlemeta_parser(sargs)],
     )
 
-    doaj_subparsers.add_parser(
+    doaj_delete_parser = doaj_subparsers.add_parser(
         "delete", help="Deleta documentos", parents=[articlemeta_parser(sargs)],
+    )
+    doaj_delete_parser.add_argument(
+        "--bulk", action="store_true", help="Deleta documentos em lote"
     )
 
     args = parser.parse_args(sargs)

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -172,7 +172,7 @@ class JobExecutor:
                 raise
 
 
-def export_document(
+def process_document(
     get_document: callable,
     index: str,
     collection: str,
@@ -220,7 +220,7 @@ def process_extracted_documents(
             )
 
         executor = JobExecutor(
-            export_document,
+            process_document,
             max_workers=4,
             success_callback=write_result,
             exception_callback=log_exception,

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -31,6 +31,10 @@ class IndexExporterHTTPError(Exception):
     pass
 
 
+class OriginDataFilterError(Exception):
+    pass
+
+
 class AMClient:
     def __init__(self, connection: str = None, domain: str = None):
         self._client = self._get_client(connection, domain)
@@ -304,6 +308,13 @@ def main_exporter(sargs):
     )
 
     args = parser.parse_args(sargs)
+
+    if args.index == "doaj" and not (
+        args.from_date or args.until_date or args.pid or args.pids
+    ):
+        raise OriginDataFilterError(
+            "Informe ao menos uma das datas (from-date ou until-date), pid ou pids"
+        )
 
     # Change Logger level
     level = getattr(logging, args.loglevel.upper())

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -109,7 +109,7 @@ class XyloseArticleExporterAdapter(interfaces.IndexExporterInterface):
 
     def _export(self):
         resp = self._send_http_request(
-            requests.post, self.index_exporter.crud_article_url, **self.post_request
+            requests.post, self.index_exporter.crud_article_put_url, **self.post_request
         )
         try:
             resp.raise_for_status()

--- a/exporter/utils.py
+++ b/exporter/utils.py
@@ -1,0 +1,5 @@
+from datetime import datetime
+
+
+def utcnow():
+    return str(datetime.utcnow().isoformat() + "Z")

--- a/exporter/utils.py
+++ b/exporter/utils.py
@@ -3,3 +3,12 @@ from datetime import datetime
 
 def utcnow():
     return str(datetime.utcnow().isoformat() + "Z")
+
+
+def get_valid_datetime(strdate: str) -> datetime:
+    try:
+        date = datetime.strptime(strdate, "%d-%m-%Y")
+    except ValueError as exc_info:
+        raise ValueError("Data inválida. Formato esperado: DD-MM-YYYY") from None
+    else:
+        return date

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ ply==3.11
 PyYAML==6.0
 requests==2.26.0
 six==1.16.0
+tenacity==8.0.1
 thriftpy2==0.4.14
 tqdm==4.62.3
 urllib3==1.26.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ python_requires = >=3.6
 install_requires =
   articlemetaapi >= 1.26
   tqdm >= 4.62
+  tenacity >= 8.0
 
 [options.extras_require]
 tests =

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,10 @@ install_requires =
   articlemetaapi >= 1.26
   tqdm >= 4.62
 
+[options.extras_require]
+tests =
+  vcrpy
+
 [options.entry_points]
 console_scripts =
     scielo-export = exporter:export_documents

--- a/tests/fixtures/full-articles.json
+++ b/tests/fixtures/full-articles.json
@@ -1,0 +1,8114 @@
+[
+  {
+      "section": {
+          "en": "Editorial",
+          "pt": "Editorial"
+      },
+      "publication_date": "1998",
+      "code": "S0100-19651998000200001",
+      "title": {
+          "v320": [
+              {
+                  "_": "DF"
+              }
+          ],
+          "v950": [
+              {
+                  "_": "MRB"
+              }
+          ],
+          "code": "0100-1965",
+          "v691": [
+              {
+                  "_": "100000000000000000000000"
+              }
+          ],
+          "v350": [
+              {
+                  "_": "es"
+              },
+              {
+                  "_": "pt"
+              }
+          ],
+          "v901": [
+              {
+                  "_": "Publicar art\u00edculos originales en el \u00e1rea de ciencia de la informaci\u00f3n o que presentem los resultados de estudios y investigaciones sobre las actividades del sector de la informaci\u00f3n",
+                  "l": "es"
+              },
+              {
+                  "_": "Publicar trabalhos originais relacionados com \u00e0 Ci\u00eancia da Informa\u00e7\u00e3o ou que apresentem resultados de estudos e pesquisas sobre as atividades do setor de informa\u00e7\u00e3o",
+                  "l": "pt"
+              },
+              {
+                  "_": "To publish original works related to Information Science, as well as the results of studies and researches in the information fields, their activities and sectors",
+                  "l": "en"
+              }
+          ],
+          "updated_at": "2019-09-04",
+          "v699": [
+              {
+                  "_": "undefined"
+              }
+          ],
+          "v480": [
+              {
+                  "_": "IBICT"
+              }
+          ],
+          "v303": [
+              {
+                  "_": "1"
+              }
+          ],
+          "processing_date": "2019-09-03",
+          "v360": [
+              {
+                  "_": "es"
+              },
+              {
+                  "_": "pt"
+              }
+          ],
+          "v62": [
+              {
+                  "_": "Instituto Brasileiro de Informa\u00e7\u00e3o em<br>Ci\u00eancia e Tecnologia - IBICT"
+              }
+          ],
+          "v441": [
+              {
+                  "_": "Applied Social Sciences"
+              }
+          ],
+          "v330": [
+              {
+                  "_": "CT"
+              }
+          ],
+          "v100": [
+              {
+                  "_": "Ci\u00eancia da Informa\u00e7\u00e3o"
+              }
+          ],
+          "v943": [
+              {
+                  "_": "20190816"
+              }
+          ],
+          "v63": [
+              {
+                  "_": "SAS, Quadra 5, Lote 6, Bloco H"
+              },
+              {
+                  "_": "70070-914 Bras\u00edlia DF - Brazil"
+              },
+              {
+                  "_": "Tel.: (55 61) 3217-6360 / 3217-6350"
+              },
+              {
+                  "_": "Fax: (55 61) 321.6490"
+              }
+          ],
+          "v951": [
+              {
+                  "_": "CM"
+              }
+          ],
+          "v450": [
+              {
+                  "_": "Bibliografia Brasileira de Ci\u00eancia da Informa\u00e7\u00e3o"
+              },
+              {
+                  "_": "Library and Information Science Abstract"
+              },
+              {
+                  "_": "Information Science Abstracts"
+              },
+              {
+                  "_": "IREBI: Indice de Revistas de Bibliotecologia"
+              }
+          ],
+          "v541": [
+              {
+                  "_": "BY-NC"
+              }
+          ],
+          "v435": [
+              {
+                  "t": "PRINT",
+                  "_": "0100-1965"
+              },
+              {
+                  "t": "ONLIN",
+                  "_": "1518-8353"
+              }
+          ],
+          "collection": "scl",
+          "v66": [
+              {
+                  "_": "art"
+              }
+          ],
+          "v5": [
+              {
+                  "_": "S"
+              }
+          ],
+          "v992": [
+              {
+                  "_": "scl"
+              }
+          ],
+          "scimago_id": "5000154508",
+          "v151": [
+              {
+                  "_": "Ci\u00eanc. inf"
+              }
+          ],
+          "v117": [
+              {
+                  "_": "other"
+              }
+          ],
+          "v310": [
+              {
+                  "_": "BR"
+              }
+          ],
+          "v302": [
+              {
+                  "_": "1"
+              }
+          ],
+          "issns": [
+              "1518-8353",
+              "0100-1965"
+          ],
+          "v490": [
+              {
+                  "_": "Bras\u00edlia"
+              }
+          ],
+          "v440": [
+              {
+                  "_": "CIENCIA DA INFORMACAO"
+              }
+          ],
+          "v51": [
+              {
+                  "_": "",
+                  "a": "20090900",
+                  "b": "C",
+                  "c": "20120600",
+                  "d": "S",
+                  "e": "suspended-by-committee"
+              },
+              {
+                  "_": "",
+                  "a": "19980430",
+                  "b": "C",
+                  "c": "20080800",
+                  "d": "S",
+                  "e": "suspended-by-committee"
+              }
+          ],
+          "v940": [
+              {
+                  "_": "19980430"
+              }
+          ],
+          "v10": [
+              {
+                  "_": "br1.1"
+              }
+          ],
+          "v64": [
+              {
+                  "_": "ciinf@ibict.br"
+              }
+          ],
+          "v400": [
+              {
+                  "_": "0100-1965"
+              }
+          ],
+          "v941": [
+              {
+                  "_": "20190903"
+              }
+          ],
+          "v301": [
+              {
+                  "_": "1972"
+              }
+          ],
+          "v67": [
+              {
+                  "_": "na"
+              }
+          ],
+          "v85": [
+              {
+                  "_": "nd"
+              }
+          ],
+          "v6": [
+              {
+                  "_": "c"
+              }
+          ],
+          "v880": [
+              {
+                  "_": "0100-1965"
+              }
+          ],
+          "v942": [
+              {
+                  "_": "19980430"
+              }
+          ],
+          "v50": [
+              {
+                  "_": "C"
+              }
+          ],
+          "v68": [
+              {
+                  "_": "ci"
+              }
+          ],
+          "v380": [
+              {
+                  "_": "T"
+              }
+          ],
+          "v30": [
+              {
+                  "_": "fbpe-012"
+              }
+          ],
+          "v935": [
+              {
+                  "_": "1518-8353"
+              }
+          ],
+          "created_at": "1998-04-30",
+          "v35": [
+              {
+                  "_": "ONLIN"
+              }
+          ],
+          "v930": [
+              {
+                  "_": "CI"
+              }
+          ],
+          "v20": [
+              {
+                  "_": "022173-2"
+              }
+          ],
+          "v854": [
+              {
+                  "_": "INFORMATION SCIENCE & LIBRARY SCIENCE"
+              }
+          ],
+          "v150": [
+              {
+                  "_": "Ci. Inf."
+              }
+          ],
+          "updated_date": "2015-05-14",
+          "v340": [
+              {
+                  "_": "A"
+              }
+          ],
+          "v65": [
+              {
+                  "_": "<hr>"
+              }
+          ]
+      },
+      "updated_at": "2019-08-17",
+      "applicable": "True",
+      "validated_wos": "False",
+      "issue": {
+          "_shard_id": "6a563b3a0db847799330f42877af3d62",
+          "publication_date": "1998",
+          "code": "0100-196519980002",
+          "collection": "scl",
+          "issue_type": "regular",
+          "publication_year": "1998",
+          "created_at": "2000-11-23",
+          "issue": {
+              "v42": [
+                  {
+                      "_": "1"
+                  }
+              ],
+              "v991": [
+                  {
+                      "_": "1"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v930": [
+                  {
+                      "_": "CI"
+                  }
+              ],
+              "v85": [
+                  {
+                      "_": "nd"
+                  }
+              ],
+              "v30": [
+                  {
+                      "_": "Ci. Inf."
+                  }
+              ],
+              "v480": [
+                  {
+                      "_": "IBICT"
+                  }
+              ],
+              "v36": [
+                  {
+                      "_": "19982"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "0100-196519980002"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "0"
+                  }
+              ],
+              "v6": [
+                  {
+                      "_": "005"
+                  }
+              ],
+              "v122": [
+                  {
+                      "_": "23"
+                  }
+              ],
+              "v48": [
+                  {
+                      "l": "es",
+                      "h": "Sumario",
+                      "_": ""
+                  },
+                  {
+                      "l": "pt",
+                      "h": "Sum\u00e1rio",
+                      "_": ""
+                  },
+                  {
+                      "l": "en",
+                      "h": "Table of Contents",
+                      "_": ""
+                  }
+              ],
+              "v32": [
+                  {
+                      "_": "2"
+                  }
+              ],
+              "v35": [
+                  {
+                      "_": "0100-1965"
+                  }
+              ],
+              "v200": [
+                  {
+                      "_": "1"
+                  }
+              ],
+              "v49": [
+                  {
+                      "_": "",
+                      "t": "Editorial",
+                      "l": "pt",
+                      "c": "CI010"
+                  },
+                  {
+                      "_": "",
+                      "t": "Artigos",
+                      "l": "pt",
+                      "c": "CI020"
+                  },
+                  {
+                      "_": "",
+                      "t": "Documentos",
+                      "l": "pt",
+                      "c": "CI030"
+                  },
+                  {
+                      "_": "",
+                      "t": "Relatos de Experi\u00eancia",
+                      "l": "pt",
+                      "c": "CI040"
+                  },
+                  {
+                      "_": "",
+                      "t": "Comunica\u00e7\u00f5es",
+                      "l": "pt",
+                      "c": "CI090"
+                  },
+                  {
+                      "_": "",
+                      "t": "Editorial",
+                      "l": "en",
+                      "c": "CI010"
+                  },
+                  {
+                      "_": "",
+                      "t": "Articles",
+                      "l": "en",
+                      "c": "CI020"
+                  },
+                  {
+                      "_": "",
+                      "t": "Documents",
+                      "l": "en",
+                      "c": "CI030"
+                  },
+                  {
+                      "_": "",
+                      "t": "Communications",
+                      "l": "en",
+                      "c": "CI090"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "1"
+                  }
+              ],
+              "v43": [
+                  {
+                      "_": "",
+                      "a": "1998",
+                      "n": "n.2",
+                      "c": "Bras\u00edlia",
+                      "v": "v.27",
+                      "t": "Ci. Inf.",
+                      "l": "es"
+                  },
+                  {
+                      "_": "",
+                      "a": "1998",
+                      "n": "n.2",
+                      "c": "Bras\u00edlia",
+                      "v": "v.27",
+                      "t": "Ci. Inf.",
+                      "l": "pt"
+                  },
+                  {
+                      "_": "",
+                      "a": "1998",
+                      "n": "n.2",
+                      "c": "Bras\u00edlia",
+                      "v": "vol.27",
+                      "t": "Ci. Inf.",
+                      "l": "en"
+                  }
+              ],
+              "v130": [
+                  {
+                      "_": "Ci\u00eancia da Informa\u00e7\u00e3o"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "i"
+                  }
+              ],
+              "v888": [
+                  {
+                      "_": "CI19982"
+                  }
+              ],
+              "v31": [
+                  {
+                      "_": "27"
+                  }
+              ],
+              "v117": [
+                  {
+                      "_": "other"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v91": [
+                  {
+                      "_": "20001123"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19980000"
+                  }
+              ]
+          },
+          "code_title": [
+              "1518-8353",
+              "0100-1965"
+          ],
+          "processing_date": "2000-11-23"
+      },
+      "doi": "10.1590/S0100-19651998000200002",
+      "processing_date": "2019-08-13",
+      "fulltexts": {
+          "html": {
+              "pt": "http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0100-19651998000200001&tlng=pt"
+          },
+          "pdf": {
+              "pt": "http://www.scielo.br/pdf/ci/v27n2/editorial.pdf"
+          }
+      },
+      "sent_wos": "False",
+      "validated_scielo": "False",
+      "code_issue": "0100-196519980002",
+      "publication_year": "1998",
+      "created_at": "1998-10-20",
+      "sent_doaj": "False",
+      "_shard_id": "2b36be43785b43e3bb62bb17547de422",
+      "license": "by-nc/4.0",
+      "collection": "scl",
+      "article": {
+          "v42": [
+              {
+                  "_": "1"
+              }
+          ],
+          "code": "S0100-19651998000200001",
+          "v882": [
+              {
+                  "n": "2",
+                  "_": "",
+                  "v": "27"
+              }
+          ],
+          "v705": [
+              {
+                  "_": "S"
+              }
+          ],
+          "v709": [
+              {
+                  "_": "text"
+              }
+          ],
+          "v10": [
+              {
+                  "_": "",
+                  "n": "Abel Laerte",
+                  "r": "nd",
+                  "s": "Packer"
+              },
+              {
+                  "_": "",
+                  "n": "Irati",
+                  "r": "nd",
+                  "s": "Antonio"
+              },
+              {
+                  "1": "a01",
+                  "_": "",
+                  "n": "Vera Slvia Maro",
+                  "r": "nd",
+                  "s": "Beraquet"
+              }
+          ],
+          "v123": [
+              {
+                  "_": "1"
+              }
+          ],
+          "v992": [
+              {
+                  "_": "scl"
+              }
+          ],
+          "v71": [
+              {
+                  "_": "ed"
+              }
+          ],
+          "v35": [
+              {
+                  "_": "0100-1965"
+              }
+          ],
+          "v2": [
+              {
+                  "_": "S0100-1965(98)02700200001"
+              }
+          ],
+          "v121": [
+              {
+                  "_": "01"
+              }
+          ],
+          "v708": [
+              {
+                  "_": "1"
+              }
+          ],
+          "v706": [
+              {
+                  "_": "h"
+              }
+          ],
+          "v30": [
+              {
+                  "_": "Ci. Inf."
+              }
+          ],
+          "v880": [
+              {
+                  "_": "S0100-19651998000200001"
+              }
+          ],
+          "v702": [
+              {
+                  "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\editorial.html"
+              }
+          ],
+          "processing_date": "2019-08-13",
+          "v700": [
+              {
+                  "_": "2"
+              }
+          ],
+          "v14": [
+              {
+                  "l": "nd",
+                  "f": "nd",
+                  "_": ""
+              }
+          ],
+          "v70": [
+              {
+                  "i": "a01",
+                  "_": "Pontifcia Universidade Catlica de Campinas",
+                  "d": "Professora do Departamento de Ps-Graduao da Faculdade de Biblioteconomia"
+              }
+          ],
+          "v38": [
+              {
+                  "_": "nd"
+              }
+          ],
+          "v3": [
+              {
+                  "_": "editorial.html"
+              }
+          ],
+          "v32": [
+              {
+                  "_": "2"
+              }
+          ],
+          "v40": [
+              {
+                  "_": "pt"
+              }
+          ],
+          "v237": [
+              {
+                  "_": "10.1590/S0100-19651998000200002"
+              }
+          ],
+          "v12": [
+              {
+                  "l": "pt",
+                  "_": "Rumo publicao eletrnica"
+              },
+              {
+                  "l": "en",
+                  "_": "Towards the electronic publishing"
+              }
+          ],
+          "v49": [
+              {
+                  "_": "CI010"
+              }
+          ],
+          "v701": [
+              {
+                  "_": "1"
+              }
+          ],
+          "v936": [
+              {
+                  "i": "0100-1965",
+                  "y": "1998",
+                  "_": "",
+                  "o": "2"
+              }
+          ],
+          "v1": [
+              {
+                  "_": "br1.1"
+              }
+          ],
+          "collection": "scl",
+          "v999": [
+              {
+                  "_": "../bases-work/ci/ci"
+              }
+          ],
+          "v31": [
+              {
+                  "_": "27"
+              }
+          ],
+          "v120": [
+              {
+                  "_": "2.0"
+              }
+          ],
+          "v4": [
+              {
+                  "_": "v27n2"
+              }
+          ],
+          "v91": [
+              {
+                  "_": "20190813"
+              }
+          ],
+          "v65": [
+              {
+                  "_": "19980000"
+              }
+          ]
+      },
+      "normalized": {
+          "article": {
+              "v70": {
+                  "p": [
+                      true
+                  ]
+              }
+          }
+      },
+      "citations": [],
+      "document_type": "editorial",
+      "code_title": [
+          "1518-8353",
+          "0100-1965"
+      ],
+      "version": "html"
+  },
+  {
+      "applicable": "True",
+      "publication_date": "1998",
+      "sent_doaj": "False",
+      "code_issue": "0100-196519980002",
+      "validated_wos": "False",
+      "sent_wos": "False",
+      "processing_date": "2019-08-13",
+      "section": {
+          "en": "Articles",
+          "pt": "Artigos"
+      },
+      "title": {
+          "v85": [
+              {
+                  "_": "nd"
+              }
+          ],
+          "v854": [
+              {
+                  "_": "INFORMATION SCIENCE & LIBRARY SCIENCE"
+              }
+          ],
+          "v63": [
+              {
+                  "_": "SAS, Quadra 5, Lote 6, Bloco H"
+              },
+              {
+                  "_": "70070-914 Bras\u00edlia DF - Brazil"
+              },
+              {
+                  "_": "Tel.: (55 61) 3217-6360 / 3217-6350"
+              },
+              {
+                  "_": "Fax: (55 61) 321.6490"
+              }
+          ],
+          "processing_date": "2019-09-03",
+          "v100": [
+              {
+                  "_": "Ci\u00eancia da Informa\u00e7\u00e3o"
+              }
+          ],
+          "v340": [
+              {
+                  "_": "A"
+              }
+          ],
+          "v30": [
+              {
+                  "_": "fbpe-012"
+              }
+          ],
+          "v67": [
+              {
+                  "_": "na"
+              }
+          ],
+          "collection": "scl",
+          "v20": [
+              {
+                  "_": "022173-2"
+              }
+          ],
+          "v450": [
+              {
+                  "_": "Bibliografia Brasileira de Ci\u00eancia da Informa\u00e7\u00e3o"
+              },
+              {
+                  "_": "Library and Information Science Abstract"
+              },
+              {
+                  "_": "Information Science Abstracts"
+              },
+              {
+                  "_": "IREBI: Indice de Revistas de Bibliotecologia"
+              }
+          ],
+          "v10": [
+              {
+                  "_": "br1.1"
+              }
+          ],
+          "v943": [
+              {
+                  "_": "20190816"
+              }
+          ],
+          "v691": [
+              {
+                  "_": "100000000000000000000000"
+              }
+          ],
+          "v303": [
+              {
+                  "_": "1"
+              }
+          ],
+          "v360": [
+              {
+                  "_": "es"
+              },
+              {
+                  "_": "pt"
+              }
+          ],
+          "v62": [
+              {
+                  "_": "Instituto Brasileiro de Informa\u00e7\u00e3o em<br>Ci\u00eancia e Tecnologia - IBICT"
+              }
+          ],
+          "v320": [
+              {
+                  "_": "DF"
+              }
+          ],
+          "v951": [
+              {
+                  "_": "CM"
+              }
+          ],
+          "v435": [
+              {
+                  "_": "0100-1965",
+                  "t": "PRINT"
+              },
+              {
+                  "_": "1518-8353",
+                  "t": "ONLIN"
+              }
+          ],
+          "v35": [
+              {
+                  "_": "ONLIN"
+              }
+          ],
+          "v440": [
+              {
+                  "_": "CIENCIA DA INFORMACAO"
+              }
+          ],
+          "v65": [
+              {
+                  "_": "<hr>"
+              }
+          ],
+          "code": "0100-1965",
+          "v330": [
+              {
+                  "_": "CT"
+              }
+          ],
+          "v490": [
+              {
+                  "_": "Bras\u00edlia"
+              }
+          ],
+          "v699": [
+              {
+                  "_": "undefined"
+              }
+          ],
+          "v66": [
+              {
+                  "_": "art"
+              }
+          ],
+          "v5": [
+              {
+                  "_": "S"
+              }
+          ],
+          "issns": [
+              "1518-8353",
+              "0100-1965"
+          ],
+          "v940": [
+              {
+                  "_": "19980430"
+              }
+          ],
+          "v400": [
+              {
+                  "_": "0100-1965"
+              }
+          ],
+          "v50": [
+              {
+                  "_": "C"
+              }
+          ],
+          "v941": [
+              {
+                  "_": "20190903"
+              }
+          ],
+          "v150": [
+              {
+                  "_": "Ci. Inf."
+              }
+          ],
+          "v942": [
+              {
+                  "_": "19980430"
+              }
+          ],
+          "v930": [
+              {
+                  "_": "CI"
+              }
+          ],
+          "v880": [
+              {
+                  "_": "0100-1965"
+              }
+          ],
+          "v901": [
+              {
+                  "_": "Publicar art\u00edculos originales en el \u00e1rea de ciencia de la informaci\u00f3n o que presentem los resultados de estudios y investigaciones sobre las actividades del sector de la informaci\u00f3n",
+                  "l": "es"
+              },
+              {
+                  "_": "Publicar trabalhos originais relacionados com \u00e0 Ci\u00eancia da Informa\u00e7\u00e3o ou que apresentem resultados de estudos e pesquisas sobre as atividades do setor de informa\u00e7\u00e3o",
+                  "l": "pt"
+              },
+              {
+                  "_": "To publish original works related to Information Science, as well as the results of studies and researches in the information fields, their activities and sectors",
+                  "l": "en"
+              }
+          ],
+          "v950": [
+              {
+                  "_": "MRB"
+              }
+          ],
+          "v64": [
+              {
+                  "_": "ciinf@ibict.br"
+              }
+          ],
+          "scimago_id": "5000154508",
+          "v310": [
+              {
+                  "_": "BR"
+              }
+          ],
+          "v380": [
+              {
+                  "_": "T"
+              }
+          ],
+          "v350": [
+              {
+                  "_": "es"
+              },
+              {
+                  "_": "pt"
+              }
+          ],
+          "v301": [
+              {
+                  "_": "1972"
+              }
+          ],
+          "updated_at": "2019-09-04",
+          "v302": [
+              {
+                  "_": "1"
+              }
+          ],
+          "v117": [
+              {
+                  "_": "other"
+              }
+          ],
+          "v935": [
+              {
+                  "_": "1518-8353"
+              }
+          ],
+          "v151": [
+              {
+                  "_": "Ci\u00eanc. inf"
+              }
+          ],
+          "updated_date": "2015-05-14",
+          "v6": [
+              {
+                  "_": "c"
+              }
+          ],
+          "v541": [
+              {
+                  "_": "BY-NC"
+              }
+          ],
+          "v51": [
+              {
+                  "_": "",
+                  "a": "20090900",
+                  "b": "C",
+                  "e": "suspended-by-committee",
+                  "c": "20120600",
+                  "d": "S"
+              },
+              {
+                  "_": "",
+                  "a": "19980430",
+                  "b": "C",
+                  "e": "suspended-by-committee",
+                  "c": "20080800",
+                  "d": "S"
+              }
+          ],
+          "v480": [
+              {
+                  "_": "IBICT"
+              }
+          ],
+          "v68": [
+              {
+                  "_": "ci"
+              }
+          ],
+          "created_at": "1998-04-30",
+          "v441": [
+              {
+                  "_": "Applied Social Sciences"
+              }
+          ],
+          "v992": [
+              {
+                  "_": "scl"
+              }
+          ]
+      },
+      "updated_at": "2019-08-17",
+      "version": "html",
+      "_shard_id": "f006367ab7444280915be7e7842b155f",
+      "code": "S0100-19651998000200002",
+      "article": {
+          "v709": [
+              {
+                  "_": "article"
+              }
+          ],
+          "v31": [
+              {
+                  "_": "27"
+              }
+          ],
+          "v85": [
+              {
+                  "_": "",
+                  "d": "nd",
+                  "i": "1"
+              },
+              {
+                  "_": "",
+                  "k": "SciELO - Scientific Electronic Library Online",
+                  "l": "pt",
+                  "i": "1",
+                  "t": "m"
+              },
+              {
+                  "_": "",
+                  "k": "Publica\u00e7\u00e3o eletr\u00f4nica",
+                  "l": "pt",
+                  "i": "1",
+                  "t": "m"
+              },
+              {
+                  "_": "",
+                  "d": "nd",
+                  "i": "2"
+              },
+              {
+                  "_": "",
+                  "k": "SciELO - Scientific Electronic Library Online",
+                  "l": "en",
+                  "i": "2",
+                  "t": "m"
+              },
+              {
+                  "_": "",
+                  "k": "Electronic publishing",
+                  "l": "en",
+                  "i": "2",
+                  "t": "m"
+              }
+          ],
+          "v12": [
+              {
+                  "_": "SciELO: uma metodologia para publica\u00e7\u00e3o eletr\u00f4nica",
+                  "l": "pt"
+              },
+              {
+                  "_": "SciELO: a methodology for electronic publishing",
+                  "l": "en"
+              }
+          ],
+          "v708": [
+              {
+                  "_": "1"
+              }
+          ],
+          "processing_date": "2019-08-13",
+          "v120": [
+              {
+                  "_": "2.0"
+              }
+          ],
+          "v705": [
+              {
+                  "_": "S"
+              }
+          ],
+          "v3": [
+              {
+                  "_": "scielo.html"
+              }
+          ],
+          "v880": [
+              {
+                  "_": "S0100-19651998000200002"
+              }
+          ],
+          "v30": [
+              {
+                  "_": "Ci. Inf."
+              }
+          ],
+          "v4": [
+              {
+                  "_": "v27n2"
+              }
+          ],
+          "v91": [
+              {
+                  "_": "20190813"
+              }
+          ],
+          "collection": "scl",
+          "v10": [
+              {
+                  "_": "",
+                  "n": "Abel Laerte",
+                  "r": "ND",
+                  "s": "Packer"
+              },
+              {
+                  "_": "",
+                  "n": "Mariana Rocha",
+                  "r": "ND",
+                  "s": "Biojone"
+              },
+              {
+                  "_": "",
+                  "n": "Irati",
+                  "r": "ND",
+                  "s": "Antonio"
+              },
+              {
+                  "_": "",
+                  "n": "Roberta Mayumi",
+                  "r": "ND",
+                  "s": "Takenaka"
+              },
+              {
+                  "_": "",
+                  "n": "Alberto Pedroso",
+                  "r": "ND",
+                  "s": "Garc\u00eda"
+              },
+              {
+                  "_": "",
+                  "n": "Asael Costa da",
+                  "r": "ND",
+                  "s": "Silva"
+              },
+              {
+                  "_": "",
+                  "n": "Renato Toshiyuki",
+                  "r": "ND",
+                  "s": "Murasaki"
+              },
+              {
+                  "_": "",
+                  "n": "Cristina",
+                  "r": "ND",
+                  "s": "Mylek"
+              },
+              {
+                  "_": "",
+                  "n": "Odila Carvalho",
+                  "r": "ND",
+                  "s": "Reis"
+              },
+              {
+                  "_": "",
+                  "n": "H\u00e1lida Cristina Rocha F.",
+                  "r": "ND",
+                  "s": "Delbucio"
+              }
+          ],
+          "v2": [
+              {
+                  "_": "S0100-1965(98)02700200002"
+              }
+          ],
+          "v14": [
+              {
+                  "f": "nd",
+                  "_": "",
+                  "l": "nd"
+              }
+          ],
+          "v121": [
+              {
+                  "_": "02"
+              }
+          ],
+          "v40": [
+              {
+                  "_": "pt"
+              }
+          ],
+          "v71": [
+              {
+                  "_": "oa"
+              }
+          ],
+          "v936": [
+              {
+                  "_": "",
+                  "y": "1998",
+                  "i": "0100-1965",
+                  "o": "2"
+              }
+          ],
+          "v701": [
+              {
+                  "_": "1"
+              }
+          ],
+          "v83": [
+              {
+                  "_": "",
+                  "a": "Descreve a Metodologia SciELO - Scientific Electronic Library Online para a publica\u00e7\u00e3o eletr\u00f4nica de peri\u00f3dicos cient\u00edficos, abordando temas como a transi\u00e7\u00e3o da publica\u00e7\u00e3o impressa em papel para a publica\u00e7\u00e3o eletr\u00f4nica, o processo de comunica\u00e7\u00e3o cient\u00edfica, os princ\u00edpios que nortearam o desenvolvimento da metodologia, sua aplica\u00e7\u00e3o no site SciELO, seus m\u00f3dulos e componentes, os instrumentos nos quais est\u00e1 baseada etc. O artigo discute, tamb\u00e9m, as potencialidades e tend\u00eancias para a \u00e1rea no Brasil e Am\u00e9rica Latina, apontando quest\u00f5es e propostas que dever\u00e3o ser abordadas e solucionadas pela metodologia. Conclui que a Metodologia SciELO \u00e9 uma solu\u00e7\u00e3o eficiente, flex\u00edvel e ampla para a publica\u00e7\u00e3o cient\u00edfica eletr\u00f4nica.",
+                  "l": "pt"
+              },
+              {
+                  "_": "",
+                  "a": "It describes the SciELO Methodology - Scientific Electronic Library Online for electronic publishing of scientific periodicals, examining issues such as the transition from traditonal printed publication to electronic publishing, the scientific communication process, the principles which founded the methodology development, its application in the building of the SciELO site, its modules and components, the tools used for its construction etc. The article also discusses the potentialities and trends for the area in Brazil and Latin America, pointing out questions and proposals which should be investigated and solved by the methodology. It concludes that the SciELO Methodology is an efficient, flexible and wide solution for the scientific electronic publishing.",
+                  "l": "en"
+              }
+          ],
+          "v65": [
+              {
+                  "_": "19980000"
+              }
+          ],
+          "v49": [
+              {
+                  "_": "CI020"
+              }
+          ],
+          "v117": [
+              {
+                  "_": "nbr6023"
+              }
+          ],
+          "v72": [
+              {
+                  "_": "24"
+              }
+          ],
+          "v42": [
+              {
+                  "_": "1"
+              }
+          ],
+          "v32": [
+              {
+                  "_": "2"
+              }
+          ],
+          "v35": [
+              {
+                  "_": "0100-1965"
+              }
+          ],
+          "v882": [
+              {
+                  "v": "27",
+                  "n": "2",
+                  "_": ""
+              }
+          ],
+          "code": "S0100-19651998000200002",
+          "v237": [
+              {
+                  "_": "10.1590/S0100-19651998000200001"
+              }
+          ],
+          "v706": [
+              {
+                  "_": "h"
+              }
+          ],
+          "v700": [
+              {
+                  "_": "2"
+              }
+          ],
+          "v1": [
+              {
+                  "_": "br1.1"
+              }
+          ],
+          "v702": [
+              {
+                  "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+              }
+          ],
+          "v999": [
+              {
+                  "_": "../bases-work/ci/ci"
+              }
+          ],
+          "v38": [
+              {
+                  "_": "FIG"
+              },
+              {
+                  "_": "TAB"
+              }
+          ],
+          "v992": [
+              {
+                  "_": "scl"
+              }
+          ]
+      },
+      "collection": "scl",
+      "created_at": "1998-10-20",
+      "license": "by-nc/4.0",
+      "issue": {
+          "issue_type": "regular",
+          "publication_date": "1998",
+          "code": "0100-196519980002",
+          "created_at": "2000-11-23",
+          "issue": {
+              "v31": [
+                  {
+                      "_": "27"
+                  }
+              ],
+              "v85": [
+                  {
+                      "_": "nd"
+                  }
+              ],
+              "v43": [
+                  {
+                      "_": "",
+                      "a": "1998",
+                      "n": "n.2",
+                      "l": "es",
+                      "t": "Ci. Inf.",
+                      "v": "v.27",
+                      "c": "Bras\u00edlia"
+                  },
+                  {
+                      "_": "",
+                      "a": "1998",
+                      "n": "n.2",
+                      "l": "pt",
+                      "t": "Ci. Inf.",
+                      "v": "v.27",
+                      "c": "Bras\u00edlia"
+                  },
+                  {
+                      "_": "",
+                      "a": "1998",
+                      "n": "n.2",
+                      "l": "en",
+                      "t": "Ci. Inf.",
+                      "v": "vol.27",
+                      "c": "Bras\u00edlia"
+                  }
+              ],
+              "v48": [
+                  {
+                      "_": "",
+                      "l": "es",
+                      "h": "Sumario"
+                  },
+                  {
+                      "_": "",
+                      "l": "pt",
+                      "h": "Sum\u00e1rio"
+                  },
+                  {
+                      "_": "",
+                      "l": "en",
+                      "h": "Table of Contents"
+                  }
+              ],
+              "v130": [
+                  {
+                      "_": "Ci\u00eancia da Informa\u00e7\u00e3o"
+                  }
+              ],
+              "v122": [
+                  {
+                      "_": "23"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "0100-196519980002"
+                  }
+              ],
+              "v30": [
+                  {
+                      "_": "Ci. Inf."
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v91": [
+                  {
+                      "_": "20001123"
+                  }
+              ],
+              "v991": [
+                  {
+                      "_": "1"
+                  }
+              ],
+              "v930": [
+                  {
+                      "_": "CI"
+                  }
+              ],
+              "v888": [
+                  {
+                      "_": "CI19982"
+                  }
+              ],
+              "v200": [
+                  {
+                      "_": "1"
+                  }
+              ],
+              "v6": [
+                  {
+                      "_": "005"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "1"
+                  }
+              ],
+              "v49": [
+                  {
+                      "_": "",
+                      "t": "Editorial",
+                      "c": "CI010",
+                      "l": "pt"
+                  },
+                  {
+                      "_": "",
+                      "t": "Artigos",
+                      "c": "CI020",
+                      "l": "pt"
+                  },
+                  {
+                      "_": "",
+                      "t": "Documentos",
+                      "c": "CI030",
+                      "l": "pt"
+                  },
+                  {
+                      "_": "",
+                      "t": "Relatos de Experi\u00eancia",
+                      "c": "CI040",
+                      "l": "pt"
+                  },
+                  {
+                      "_": "",
+                      "t": "Comunica\u00e7\u00f5es",
+                      "c": "CI090",
+                      "l": "pt"
+                  },
+                  {
+                      "_": "",
+                      "t": "Editorial",
+                      "c": "CI010",
+                      "l": "en"
+                  },
+                  {
+                      "_": "",
+                      "t": "Articles",
+                      "c": "CI020",
+                      "l": "en"
+                  },
+                  {
+                      "_": "",
+                      "t": "Documents",
+                      "c": "CI030",
+                      "l": "en"
+                  },
+                  {
+                      "_": "",
+                      "t": "Communications",
+                      "c": "CI090",
+                      "l": "en"
+                  }
+              ],
+              "v117": [
+                  {
+                      "_": "other"
+                  }
+              ],
+              "v42": [
+                  {
+                      "_": "1"
+                  }
+              ],
+              "v32": [
+                  {
+                      "_": "2"
+                  }
+              ],
+              "v35": [
+                  {
+                      "_": "0100-1965"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v480": [
+                  {
+                      "_": "IBICT"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "i"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "0"
+                  }
+              ],
+              "v36": [
+                  {
+                      "_": "19982"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          "processing_date": "2000-11-23",
+          "code_title": [
+              "1518-8353",
+              "0100-1965"
+          ],
+          "publication_year": "1998",
+          "_shard_id": "6a563b3a0db847799330f42877af3d62",
+          "collection": "scl"
+      },
+      "citations": [
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v801": [
+                  {
+                      "_": "SCIENTOMETRICS"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v12": [
+                  {
+                      "_": "Brazilian production in biochemistry: the question of international versus domestic publication",
+                      "l": "en"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19920100"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200001"
+                  }
+              ],
+              "v30": [
+                  {
+                      "_": "Scientometrics"
+                  }
+              ],
+              "code": "S0100-1965199800020000200001",
+              "v32": [
+                  {
+                      "_": "1"
+                  }
+              ],
+              "v35": [
+                  {
+                      "_": "0138-9130"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "1"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "1"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v10": [
+                  {
+                      "_": "",
+                      "n": "Rog\u00e9rio",
+                      "r": "ND",
+                      "s": "MENEGHINI"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "267"
+                  }
+              ],
+              "v14": [
+                  {
+                      "_": "21-30"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "jan. 1992"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v31": [
+                  {
+                      "_": "23"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v56": [
+                  {
+                      "_": "Rio de Janeiro",
+                      "i": "1"
+                  }
+              ],
+              "v12": [
+                  {
+                      "_": "Publica\u00e7\u00f5es eletr\u00f4nicas, controle bibliogr\u00e1fico e recupera\u00e7\u00e3o de informa\u00e7\u00e3o: um enfoque integrado",
+                      "l": "pt"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "268"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200002"
+                  }
+              ],
+              "code": "S0100-1965199800020000200002",
+              "v54": [
+                  {
+                      "_": "1996",
+                      "i": "1"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "2"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19980810"
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v55": [
+                  {
+                      "_": "19960000",
+                      "i": "1"
+                  }
+              ],
+              "v53": [
+                  {
+                      "_": "CONGRESSO REGIONAL DE INFORMA\u00c7\u00c3O EM CI\u00caNCIAS DA SA\u00daDE",
+                      "n": "3",
+                      "i": "1"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "2"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v10": [
+                  {
+                      "_": "",
+                      "n": "Abel L.",
+                      "r": "ND",
+                      "s": "PACKER"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "10 ago. 1998"
+                  }
+              ],
+              "v61": [
+                  {
+                      "_": "Dispon\u00edvel em WWW: [http://www.bireme.br/cgi-bin/crics3/text0?id=crics3-mr1.2-mr1.2.2-04]"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v18": [
+                  {
+                      "_": "Anais",
+                      "l": "pt"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v16": [
+                  {
+                      "_": "",
+                      "n": "R.P.",
+                      "r": "ED",
+                      "s": "PEEK"
+                  },
+                  {
+                      "_": "",
+                      "n": "G.B.",
+                      "r": "ED",
+                      "s": "NEWBY"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v12": [
+                  {
+                      "_": "Scholarly publishing, facing the new frontiers.",
+                      "l": "en"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v64": [
+                  {
+                      "_": "1996"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "269"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200003"
+                  }
+              ],
+              "code": "S0100-1965199800020000200003",
+              "v701": [
+                  {
+                      "_": "3"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19960000"
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v20": [
+                  {
+                      "_": "363"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "3"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v10": [
+                  {
+                      "_": "",
+                      "n": "R.P.",
+                      "r": "ND",
+                      "s": "PEEK"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "MIT Press"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "Cambridge"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v18": [
+                  {
+                      "_": "Scholarly publishing: the electronic frontier",
+                      "l": "en"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v801": [
+                  {
+                      "_": "INFORMATION TECHNOLOGY AND LIBRARIES"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v12": [
+                  {
+                      "_": "Issues and experiments in electronic publishing and dissemination.",
+                      "l": "en"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19940600"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "270"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200004"
+                  }
+              ],
+              "v30": [
+                  {
+                      "_": "Information Technology and Libraries"
+                  }
+              ],
+              "code": "S0100-1965199800020000200004",
+              "v35": [
+                  {
+                      "_": "0730-9295"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "4"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "4"
+                  }
+              ],
+              "v10": [
+                  {
+                      "_": "",
+                      "n": "K.",
+                      "r": "ND",
+                      "s": "HUNTER"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v14": [
+                  {
+                      "_": "127-32"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "June 1994"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v16": [
+                  {
+                      "_": "",
+                      "n": "C.W.",
+                      "r": "ND",
+                      "s": "BAILEY JUNIOR"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v64": [
+                  {
+                      "_": "1998"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "271"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200005"
+                  }
+              ],
+              "code": "S0100-1965199800020000200005",
+              "v701": [
+                  {
+                      "_": "5"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "5"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "University of Houston"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "Houston"
+                  }
+              ],
+              "v61": [
+                  {
+                      "_": "[cited July 1998]. Available at WWW: <http://info.lib.uh.edu/sepb/sepb.html&gt;"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v18": [
+                  {
+                      "_": "Scholarly electronic publishing bibliography [online]:: version 19.",
+                      "l": "en"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v801": [
+                  {
+                      "_": "LIBRARY TRENDS"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v12": [
+                  {
+                      "_": "Evolution of electronic publishing",
+                      "l": "en"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19950000"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200006"
+                  }
+              ],
+              "v30": [
+                  {
+                      "_": "Library Trends"
+                  }
+              ],
+              "code": "S0100-1965199800020000200006",
+              "v32": [
+                  {
+                      "_": "4"
+                  }
+              ],
+              "v35": [
+                  {
+                      "_": "0024-2594"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "6"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "6"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v10": [
+                  {
+                      "_": "",
+                      "n": "F.W.",
+                      "r": "ND",
+                      "s": "LANCASTER"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "272"
+                  }
+              ],
+              "v14": [
+                  {
+                      "_": "3-7"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1995"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v31": [
+                  {
+                      "_": "43"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v801": [
+                  {
+                      "_": "LIBRARY TRENDS"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v12": [
+                  {
+                      "_": "Present and future capabilities of the online journal.",
+                      "l": "en"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19950000"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200007"
+                  }
+              ],
+              "v30": [
+                  {
+                      "_": "Library Trends"
+                  }
+              ],
+              "code": "S0100-1965199800020000200007",
+              "v32": [
+                  {
+                      "_": "4"
+                  }
+              ],
+              "v35": [
+                  {
+                      "_": "0024-2594"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "7"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "7"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v10": [
+                  {
+                      "_": "",
+                      "n": "T.B.",
+                      "r": "ND",
+                      "s": "HICKEY"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "273"
+                  }
+              ],
+              "v14": [
+                  {
+                      "_": "528-43"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1995"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v31": [
+                  {
+                      "_": "43"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v16": [
+                  {
+                      "_": "",
+                      "n": "M.",
+                      "r": "ND",
+                      "s": "BORGHUIS"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v64": [
+                  {
+                      "_": "1996"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "274"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200008"
+                  }
+              ],
+              "code": "S0100-1965199800020000200008",
+              "v701": [
+                  {
+                      "_": "8"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19960000"
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "8"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "Elsevier Science"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "New York"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v18": [
+                  {
+                      "_": "TULIP: final report",
+                      "l": "en"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v801": [
+                  {
+                      "_": "DIGITAL LIBRARIES"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v12": [
+                  {
+                      "_": "COMMUNICATIONS of the ACM: The Second International Conference on the Theory and Practice of Digital Libraries.",
+                      "l": "en"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "275"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200009"
+                  }
+              ],
+              "v30": [
+                  {
+                      "_": "Digital Libraries"
+                  }
+              ],
+              "code": "S0100-1965199800020000200009",
+              "v32": [
+                  {
+                      "_": "4"
+                  }
+              ],
+              "v35": [
+                  {
+                      "_": "1340-7287"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "9"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19950000"
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "9"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1995"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v31": [
+                  {
+                      "_": "38"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v16": [
+                  {
+                      "_": "",
+                      "n": "J.-C.",
+                      "r": "ND",
+                      "s": "GUEDON"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v700": [
+                  {
+                      "_": "276"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200010"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "10"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "10"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "code": "S0100-1965199800020000200010",
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v61": [
+                  {
+                      "_": "[online]. [cited 10 Nov. 1997]. Available from URL: [http://poe.acc.virginia.edu/~pm9k/libsci/guedon.html]"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v18": [
+                  {
+                      "_": "Why are electronic publications difficult to classify?: the orthogonality of print and digital media",
+                      "l": "en"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v801": [
+                  {
+                      "_": "INFORMATION TECHNOLOGY AND LIBRARIES"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v12": [
+                  {
+                      "_": "The future of scientific journals: lessons from the past.",
+                      "l": "en"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19941200"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "277"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200011"
+                  }
+              ],
+              "v30": [
+                  {
+                      "_": "Information Technology and Libraries"
+                  }
+              ],
+              "code": "S0100-1965199800020000200011",
+              "v35": [
+                  {
+                      "_": "0730-9295"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "11"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "11"
+                  }
+              ],
+              "v10": [
+                  {
+                      "_": "",
+                      "n": "A.C.",
+                      "r": "ND",
+                      "s": "SCHAFFNER"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v14": [
+                  {
+                      "_": "239-47"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "Dec. 1994"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v31": [
+                  {
+                      "_": "11"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v12": [
+                  {
+                      "_": "The post-Gutenberg galaxy: how to get there from here",
+                      "l": "en"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v710": [
+                  {
+                      "_": "2"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19950000"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "278"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200012"
+                  }
+              ],
+              "v30": [
+                  {
+                      "_": "The Information Society"
+                  }
+              ],
+              "code": "S0100-1965199800020000200012",
+              "v32": [
+                  {
+                      "_": "4"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "12"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "12"
+                  }
+              ],
+              "v10": [
+                  {
+                      "_": "",
+                      "n": "S.",
+                      "r": "ND",
+                      "s": "HARNAD"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v14": [
+                  {
+                      "_": "285-91"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1995"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v31": [
+                  {
+                      "_": "11"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v12": [
+                  {
+                      "_": "Electronic journals: neither free nor easy.",
+                      "l": "en"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v710": [
+                  {
+                      "_": "2"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19950000"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "279"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200013"
+                  }
+              ],
+              "v30": [
+                  {
+                      "_": "The Information Society"
+                  }
+              ],
+              "code": "S0100-1965199800020000200013",
+              "v32": [
+                  {
+                      "_": "4"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "13"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "13"
+                  }
+              ],
+              "v10": [
+                  {
+                      "_": "",
+                      "n": "F.",
+                      "r": "ND",
+                      "s": "ROWLAND"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v14": [
+                  {
+                      "_": "273-4"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1995"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v801": [
+                  {
+                      "_": "Scientific American"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v12": [
+                  {
+                      "_": "Going digital",
+                      "l": "en"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19970300"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200014"
+                  }
+              ],
+              "v30": [
+                  {
+                      "_": "Scientific American"
+                  }
+              ],
+              "code": "S0100-1965199800020000200014",
+              "v32": [
+                  {
+                      "_": "3"
+                  }
+              ],
+              "v35": [
+                  {
+                      "_": "0036-8733"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "14"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "14"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v10": [
+                  {
+                      "_": "",
+                      "n": "Michael",
+                      "r": "ND",
+                      "s": "LESK"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "280"
+                  }
+              ],
+              "v14": [
+                  {
+                      "_": "58-60"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "Mar. 1997"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v31": [
+                  {
+                      "_": "276"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v12": [
+                  {
+                      "_": "Em busca da nossa ci\u00eancia perdida",
+                      "l": "pt"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v710": [
+                  {
+                      "_": "2"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19970324"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "281"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200015"
+                  }
+              ],
+              "v30": [
+                  {
+                      "_": "Jornal da USP"
+                  }
+              ],
+              "code": "S0100-1965199800020000200015",
+              "v701": [
+                  {
+                      "_": "15"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "15"
+                  }
+              ],
+              "v10": [
+                  {
+                      "_": "",
+                      "n": "Rog\u00e9rio",
+                      "r": "ND",
+                      "s": "MENEGHINI"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v14": [
+                  {
+                      "_": "2"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "24 mar. 1997"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "S\u00e3o Paulo"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v17": [
+                  {
+                      "_": "ISO"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "282"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200016"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "16"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19860000"
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "16"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "code": "S0100-1965199800020000200016",
+              "v64": [
+                  {
+                      "_": "1986"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "Gen\u00e9ve"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v18": [
+                  {
+                      "_": "Standard Generalized Markup Language - SGML (ISO 8879)",
+                      "l": "en"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v17": [
+                  {
+                      "_": "ISO"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "283"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200017"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19940000"
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "code": "S0100-1965199800020000200017",
+              "v64": [
+                  {
+                      "_": "1994"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "Gen\u00e9ve"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v18": [
+                  {
+                      "_": "Electronic Manuscript Preparation and Markup (ISO 12083)",
+                      "l": "en"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v16": [
+                  {
+                      "_": "",
+                      "n": "N.A.F.M.",
+                      "r": "ND",
+                      "s": "POPPELIER"
+                  },
+                  {
+                      "_": "",
+                      "n": "H.",
+                      "r": "ND",
+                      "s": "VAN DER TOGT"
+                  },
+                  {
+                      "_": "",
+                      "n": "F.K.",
+                      "r": "ND",
+                      "s": "VELDMEIJER"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v64": [
+                  {
+                      "_": "1995"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "284"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200018"
+                  }
+              ],
+              "code": "S0100-1965199800020000200018",
+              "v701": [
+                  {
+                      "_": "18"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19950000"
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "18"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "Elsevier Science"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "Amsterdam"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v18": [
+                  {
+                      "_": "Documentation of the Elsevier Science Article DTD (version 3.0.0).",
+                      "l": "en"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v17": [
+                  {
+                      "_": "EUROPEAN GROUP ON SGML"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200019"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "19"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19910000"
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v20": [
+                  {
+                      "_": "150"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "19"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "285"
+                  }
+              ],
+              "code": "S0100-1965199800020000200019",
+              "v64": [
+                  {
+                      "_": "1991"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v18": [
+                  {
+                      "_": "MAJOUR-Header DTD",
+                      "l": "en"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "286"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200020"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "20"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19980810"
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "20"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "code": "S0100-1965199800020000200020",
+              "v64": [
+                  {
+                      "_": "cited 10 Aug. 1998"
+                  }
+              ],
+              "v61": [
+                  {
+                      "_": "Available at WWW: [http://www.jclark.com/sp/index.htm]"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v18": [
+                  {
+                      "_": "SP: an SGML system conforming to international standard ISO 8879 - Standard Generalized Markup Language",
+                      "l": "en"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v17": [
+                  {
+                      "_": "BIREME"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "287"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200021"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "21"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19970000"
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "21"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "code": "S0100-1965199800020000200021",
+              "v64": [
+                  {
+                      "_": "1997"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "S\u00e3o Paulo"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v18": [
+                  {
+                      "_": "ISIS aplication program interface: ISIS_DLL user's manual. Preliminary version.",
+                      "l": "en"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v17": [
+                  {
+                      "_": "BIREME"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "288"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200022"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "22"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19970000"
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "22"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "code": "S0100-1965199800020000200022",
+              "v64": [
+                  {
+                      "_": "1997"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "S\u00e3o Paulo"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v18": [
+                  {
+                      "_": "WWWISIS: a world wide web server for ISIS-databases. Version 3.0.",
+                      "l": "en"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v16": [
+                  {
+                      "_": "",
+                      "n": "C.F.",
+                      "r": "ND",
+                      "s": "GOLDFARB"
+                  },
+                  {
+                      "_": "",
+                      "n": "P.",
+                      "r": "ND",
+                      "s": "PRESCOD"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v64": [
+                  {
+                      "_": "1998"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200023"
+                  }
+              ],
+              "code": "S0100-1965199800020000200023",
+              "v701": [
+                  {
+                      "_": "23"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v20": [
+                  {
+                      "_": "639"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "23"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "289"
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "Prentice Hall"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "Upper Saddle River"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v18": [
+                  {
+                      "_": "The XML handbook.",
+                      "l": "en"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          },
+          {
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v16": [
+                  {
+                      "_": "",
+                      "n": "Abel L.",
+                      "r": "ED",
+                      "s": "PACKER"
+                  },
+                  {
+                      "_": "",
+                      "n": "Elenice",
+                      "r": "ED",
+                      "s": "CASTRO"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "y": "1998",
+                      "i": "0100-1965",
+                      "o": "2"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\scielo.html"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v64": [
+                  {
+                      "_": "1998"
+                  }
+              ],
+              "v882": [
+                  {
+                      "v": "27",
+                      "n": "2",
+                      "_": ""
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "290"
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000200024"
+                  }
+              ],
+              "code": "S0100-1965199800020000200024",
+              "v701": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "collection": "scl",
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "24"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "scielo.html"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200002"
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "BIREME"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "S\u00e3o Paulo"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v18": [
+                  {
+                      "_": "Biblioteca virtual en salud",
+                      "l": "es"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ]
+          }
+      ],
+      "doi": "10.1590/S0100-19651998000200001",
+      "fulltexts": {
+          "html": {
+              "pt": "http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0100-19651998000200002&tlng=pt"
+          },
+          "pdf": {
+              "pt": "http://www.scielo.br/pdf/ci/v27n2/scielo.pdf"
+          }
+      },
+      "code_title": [
+          "1518-8353",
+          "0100-1965"
+      ],
+      "publication_year": "1998",
+      "validated_scielo": "False",
+      "document_type": "research-article"
+  },
+  {
+      "publication_date": "1998",
+      "code_title": [
+          "1518-8353",
+          "0100-1965"
+      ],
+      "updated_at": "2019-08-17",
+      "sent_wos": "False",
+      "document_type": "research-article",
+      "applicable": "True",
+      "issue": {
+          "issue_type": "regular",
+          "publication_date": "1998",
+          "created_at": "2000-11-23",
+          "code_title": [
+              "1518-8353",
+              "0100-1965"
+          ],
+          "issue": {
+              "v6": [
+                  {
+                      "_": "005"
+                  }
+              ],
+              "v117": [
+                  {
+                      "_": "other"
+                  }
+              ],
+              "v888": [
+                  {
+                      "_": "CI19982"
+                  }
+              ],
+              "v91": [
+                  {
+                      "_": "20001123"
+                  }
+              ],
+              "v122": [
+                  {
+                      "_": "23"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "1"
+                  }
+              ],
+              "v31": [
+                  {
+                      "_": "27"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v35": [
+                  {
+                      "_": "0100-1965"
+                  }
+              ],
+              "v42": [
+                  {
+                      "_": "1"
+                  }
+              ],
+              "v930": [
+                  {
+                      "_": "CI"
+                  }
+              ],
+              "v49": [
+                  {
+                      "t": "Editorial",
+                      "l": "pt",
+                      "_": "",
+                      "c": "CI010"
+                  },
+                  {
+                      "t": "Artigos",
+                      "l": "pt",
+                      "_": "",
+                      "c": "CI020"
+                  },
+                  {
+                      "t": "Documentos",
+                      "l": "pt",
+                      "_": "",
+                      "c": "CI030"
+                  },
+                  {
+                      "t": "Relatos de Experi\u00eancia",
+                      "l": "pt",
+                      "_": "",
+                      "c": "CI040"
+                  },
+                  {
+                      "t": "Comunica\u00e7\u00f5es",
+                      "l": "pt",
+                      "_": "",
+                      "c": "CI090"
+                  },
+                  {
+                      "t": "Editorial",
+                      "l": "en",
+                      "_": "",
+                      "c": "CI010"
+                  },
+                  {
+                      "t": "Articles",
+                      "l": "en",
+                      "_": "",
+                      "c": "CI020"
+                  },
+                  {
+                      "t": "Documents",
+                      "l": "en",
+                      "_": "",
+                      "c": "CI030"
+                  },
+                  {
+                      "t": "Communications",
+                      "l": "en",
+                      "_": "",
+                      "c": "CI090"
+                  }
+              ],
+              "v30": [
+                  {
+                      "_": "Ci. Inf."
+                  }
+              ],
+              "v48": [
+                  {
+                      "h": "Sumario",
+                      "l": "es",
+                      "_": ""
+                  },
+                  {
+                      "h": "Sum\u00e1rio",
+                      "l": "pt",
+                      "_": ""
+                  },
+                  {
+                      "h": "Table of Contents",
+                      "l": "en",
+                      "_": ""
+                  }
+              ],
+              "v880": [
+                  {
+                      "_": "0100-196519980002"
+                  }
+              ],
+              "v85": [
+                  {
+                      "_": "nd"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v43": [
+                  {
+                      "n": "n.2",
+                      "t": "Ci. Inf.",
+                      "_": "",
+                      "c": "Bras\u00edlia",
+                      "a": "1998",
+                      "l": "es",
+                      "v": "v.27"
+                  },
+                  {
+                      "n": "n.2",
+                      "t": "Ci. Inf.",
+                      "_": "",
+                      "c": "Bras\u00edlia",
+                      "a": "1998",
+                      "l": "pt",
+                      "v": "v.27"
+                  },
+                  {
+                      "n": "n.2",
+                      "t": "Ci. Inf.",
+                      "_": "",
+                      "c": "Bras\u00edlia",
+                      "a": "1998",
+                      "l": "en",
+                      "v": "vol.27"
+                  }
+              ],
+              "v200": [
+                  {
+                      "_": "1"
+                  }
+              ],
+              "v36": [
+                  {
+                      "_": "19982"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "i"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "0"
+                  }
+              ],
+              "v32": [
+                  {
+                      "_": "2"
+                  }
+              ],
+              "v130": [
+                  {
+                      "_": "Ci\u00eancia da Informa\u00e7\u00e3o"
+                  }
+              ],
+              "v480": [
+                  {
+                      "_": "IBICT"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v991": [
+                  {
+                      "_": "1"
+                  }
+              ]
+          },
+          "publication_year": "1998",
+          "code": "0100-196519980002",
+          "collection": "scl",
+          "_shard_id": "6a563b3a0db847799330f42877af3d62",
+          "processing_date": "2000-11-23"
+      },
+      "section": {
+          "pt": "Artigos",
+          "en": "Articles"
+      },
+      "fulltexts": {
+          "html": {
+              "pt": "http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0100-19651998000200003&tlng=pt"
+          },
+          "pdf": {
+              "pt": "http://www.scielo.br/pdf/ci/v27n2/barreto.pdf"
+          }
+      },
+      "code": "S0100-19651998000200003",
+      "version": "html",
+      "collection": "scl",
+      "doi": "10.1590/S0100-19651998000200003",
+      "validated_wos": "False",
+      "_shard_id": "8bc6f7b5b0f1453fa2f97c95046f05cf",
+      "license": "by-nc/4.0",
+      "title": {
+          "v6": [
+              {
+                  "_": "c"
+              }
+          ],
+          "v117": [
+              {
+                  "_": "other"
+              }
+          ],
+          "updated_at": "2019-09-04",
+          "v901": [
+              {
+                  "l": "es",
+                  "_": "Publicar art\u00edculos originales en el \u00e1rea de ciencia de la informaci\u00f3n o que presentem los resultados de estudios y investigaciones sobre las actividades del sector de la informaci\u00f3n"
+              },
+              {
+                  "l": "pt",
+                  "_": "Publicar trabalhos originais relacionados com \u00e0 Ci\u00eancia da Informa\u00e7\u00e3o ou que apresentem resultados de estudos e pesquisas sobre as atividades do setor de informa\u00e7\u00e3o"
+              },
+              {
+                  "l": "en",
+                  "_": "To publish original works related to Information Science, as well as the results of studies and researches in the information fields, their activities and sectors"
+              }
+          ],
+          "v951": [
+              {
+                  "_": "CM"
+              }
+          ],
+          "v50": [
+              {
+                  "_": "C"
+              }
+          ],
+          "v35": [
+              {
+                  "_": "ONLIN"
+              }
+          ],
+          "v320": [
+              {
+                  "_": "DF"
+              }
+          ],
+          "v20": [
+              {
+                  "_": "022173-2"
+              }
+          ],
+          "v302": [
+              {
+                  "_": "1"
+              }
+          ],
+          "v435": [
+              {
+                  "t": "PRINT",
+                  "_": "0100-1965"
+              },
+              {
+                  "t": "ONLIN",
+                  "_": "1518-8353"
+              }
+          ],
+          "v940": [
+              {
+                  "_": "19980430"
+              }
+          ],
+          "collection": "scl",
+          "scimago_id": "5000154508",
+          "v10": [
+              {
+                  "_": "br1.1"
+              }
+          ],
+          "v5": [
+              {
+                  "_": "S"
+              }
+          ],
+          "v85": [
+              {
+                  "_": "nd"
+              }
+          ],
+          "v65": [
+              {
+                  "_": "<hr>"
+              }
+          ],
+          "created_at": "1998-04-30",
+          "v400": [
+              {
+                  "_": "0100-1965"
+              }
+          ],
+          "v68": [
+              {
+                  "_": "ci"
+              }
+          ],
+          "v943": [
+              {
+                  "_": "20190816"
+              }
+          ],
+          "v63": [
+              {
+                  "_": "SAS, Quadra 5, Lote 6, Bloco H"
+              },
+              {
+                  "_": "70070-914 Bras\u00edlia DF - Brazil"
+              },
+              {
+                  "_": "Tel.: (55 61) 3217-6360 / 3217-6350"
+              },
+              {
+                  "_": "Fax: (55 61) 321.6490"
+              }
+          ],
+          "v350": [
+              {
+                  "_": "es"
+              },
+              {
+                  "_": "pt"
+              }
+          ],
+          "processing_date": "2019-09-03",
+          "v62": [
+              {
+                  "_": "Instituto Brasileiro de Informa\u00e7\u00e3o em<br>Ci\u00eancia e Tecnologia - IBICT"
+              }
+          ],
+          "v699": [
+              {
+                  "_": "undefined"
+              }
+          ],
+          "v360": [
+              {
+                  "_": "es"
+              },
+              {
+                  "_": "pt"
+              }
+          ],
+          "v480": [
+              {
+                  "_": "IBICT"
+              }
+          ],
+          "v66": [
+              {
+                  "_": "art"
+              }
+          ],
+          "v151": [
+              {
+                  "_": "Ci\u00eanc. inf"
+              }
+          ],
+          "v992": [
+              {
+                  "_": "scl"
+              }
+          ],
+          "v51": [
+              {
+                  "e": "suspended-by-committee",
+                  "_": "",
+                  "c": "20120600",
+                  "a": "20090900",
+                  "b": "C",
+                  "d": "S"
+              },
+              {
+                  "e": "suspended-by-committee",
+                  "_": "",
+                  "c": "20080800",
+                  "a": "19980430",
+                  "b": "C",
+                  "d": "S"
+              }
+          ],
+          "v941": [
+              {
+                  "_": "20190903"
+              }
+          ],
+          "v950": [
+              {
+                  "_": "MRB"
+              }
+          ],
+          "v303": [
+              {
+                  "_": "1"
+              }
+          ],
+          "v691": [
+              {
+                  "_": "100000000000000000000000"
+              }
+          ],
+          "v930": [
+              {
+                  "_": "CI"
+              }
+          ],
+          "v310": [
+              {
+                  "_": "BR"
+              }
+          ],
+          "v30": [
+              {
+                  "_": "fbpe-012"
+              }
+          ],
+          "issns": [
+              "1518-8353",
+              "0100-1965"
+          ],
+          "code": "0100-1965",
+          "v340": [
+              {
+                  "_": "A"
+              }
+          ],
+          "v490": [
+              {
+                  "_": "Bras\u00edlia"
+              }
+          ],
+          "v380": [
+              {
+                  "_": "T"
+              }
+          ],
+          "v441": [
+              {
+                  "_": "Applied Social Sciences"
+              }
+          ],
+          "v150": [
+              {
+                  "_": "Ci. Inf."
+              }
+          ],
+          "v880": [
+              {
+                  "_": "0100-1965"
+              }
+          ],
+          "v330": [
+              {
+                  "_": "CT"
+              }
+          ],
+          "updated_date": "2015-05-14",
+          "v301": [
+              {
+                  "_": "1972"
+              }
+          ],
+          "v450": [
+              {
+                  "_": "Bibliografia Brasileira de Ci\u00eancia da Informa\u00e7\u00e3o"
+              },
+              {
+                  "_": "Library and Information Science Abstract"
+              },
+              {
+                  "_": "Information Science Abstracts"
+              },
+              {
+                  "_": "IREBI: Indice de Revistas de Bibliotecologia"
+              }
+          ],
+          "v67": [
+              {
+                  "_": "na"
+              }
+          ],
+          "v942": [
+              {
+                  "_": "19980430"
+              }
+          ],
+          "v100": [
+              {
+                  "_": "Ci\u00eancia da Informa\u00e7\u00e3o"
+              }
+          ],
+          "v935": [
+              {
+                  "_": "1518-8353"
+              }
+          ],
+          "v64": [
+              {
+                  "_": "ciinf@ibict.br"
+              }
+          ],
+          "v541": [
+              {
+                  "_": "BY-NC"
+              }
+          ],
+          "v854": [
+              {
+                  "_": "INFORMATION SCIENCE & LIBRARY SCIENCE"
+              }
+          ],
+          "v440": [
+              {
+                  "_": "CIENCIA DA INFORMACAO"
+              }
+          ]
+      },
+      "created_at": "1998-10-20",
+      "code_issue": "0100-196519980002",
+      "publication_year": "1998",
+      "sent_doaj": "False",
+      "processing_date": "2019-08-13",
+      "article": {
+          "v117": [
+              {
+                  "_": "nbr6023"
+              }
+          ],
+          "v708": [
+              {
+                  "_": "1"
+              }
+          ],
+          "v91": [
+              {
+                  "_": "20190813"
+              }
+          ],
+          "v709": [
+              {
+                  "_": "article"
+              }
+          ],
+          "v701": [
+              {
+                  "_": "1"
+              }
+          ],
+          "v31": [
+              {
+                  "_": "27"
+              }
+          ],
+          "v4": [
+              {
+                  "_": "v27n2"
+              }
+          ],
+          "v35": [
+              {
+                  "_": "0100-1965"
+              }
+          ],
+          "v72": [
+              {
+                  "_": "17"
+              }
+          ],
+          "v1": [
+              {
+                  "_": "bjg"
+              }
+          ],
+          "v65": [
+              {
+                  "_": "19980000"
+              }
+          ],
+          "v49": [
+              {
+                  "_": "CI020"
+              }
+          ],
+          "v30": [
+              {
+                  "_": "Ci. Inf."
+              }
+          ],
+          "v3": [
+              {
+                  "_": "barreto.html"
+              }
+          ],
+          "v702": [
+              {
+                  "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+              }
+          ],
+          "collection": "scl",
+          "v882": [
+              {
+                  "n": "2",
+                  "v": "27",
+                  "_": ""
+              }
+          ],
+          "v10": [
+              {
+                  "n": "Aldo de Albuquerque",
+                  "r": "ND",
+                  "1": "A01",
+                  "s": "Barreto",
+                  "_": ""
+              }
+          ],
+          "v12": [
+              {
+                  "l": "pt",
+                  "_": "Mudan\u00e7a estrutural no fluxo do conhecimento: a comunica\u00e7\u00e3o eletr\u00f4nica"
+              },
+              {
+                  "l": "en",
+                  "_": "Structural change of the knowledge flow: the electronic communication"
+              }
+          ],
+          "v40": [
+              {
+                  "_": "pt"
+              }
+          ],
+          "code": "S0100-19651998000200003",
+          "v880": [
+              {
+                  "_": "S0100-19651998000200003"
+              }
+          ],
+          "v83": [
+              {
+                  "l": "pt",
+                  "_": "",
+                  "a": "A estrutura da rela\u00e7\u00e3o entre o fluxo de informa\u00e7\u00e3o e o p\u00fablico a quem o conhecimento \u00e9 dirigido vem se modificando com o tempo, como uma fun\u00e7\u00e3o das diferentes t\u00e9cnicas que operam na transfer\u00eancia da informa\u00e7\u00e3o, do gerador ao receptor. O fluxo em si, uma sucess\u00e3o de eventos, de um processo de media\u00e7\u00e3o, entre a gera\u00e7\u00e3o da informa\u00e7\u00e3o por uma fonte emissora, e a aceita\u00e7\u00e3o da informa\u00e7\u00e3o pela entidade receptora, realiza uma das bases conceituais que se acredita ser o cerne da ci\u00eancia da informa\u00e7\u00e3o: a gera\u00e7\u00e3o de conhecimento no indiv\u00edduo e no seu espa\u00e7o de conviv\u00eancia. Assim, o prop\u00f3sito deste artigo \u00e9 mostrar que o fluxo da informa\u00e7\u00e3o que interliga gerador e receptor vem agregando compet\u00eancia na transmiss\u00e3o, em uma rela\u00e7\u00e3o direta com as fases por que passou o desenvolvimento do processo de transfer\u00eancia da informa\u00e7\u00e3o at\u00e9 chegar ao tempo da comunica\u00e7\u00e3o eletr\u00f4nica que viabiliza com maior intensidade a rela\u00e7\u00e3o de intera\u00e7\u00e3o que nos interessa observar."
+              },
+              {
+                  "l": "en",
+                  "_": "",
+                  "a": "The relationship between the information flow and the public, which is exposed to knowledge assimilation, has changed its structural model. Information technology has played a major role in this changing process. The electronic communication is analyzed as a way of disseminating information more profitable to the user than the oral or written process. The publicity of information and knowledge has become more efficient and accessible in the computer era."
+              }
+          ],
+          "v85": [
+              {
+                  "d": "nd",
+                  "_": "",
+                  "i": "1"
+              },
+              {
+                  "t": "m",
+                  "l": "pt",
+                  "k": "Comunica\u00e7\u00e3o do conhecimento",
+                  "_": "",
+                  "i": "1"
+              },
+              {
+                  "t": "m",
+                  "l": "pt",
+                  "k": "Fluxo de informa\u00e7\u00e3o",
+                  "_": "",
+                  "i": "1"
+              },
+              {
+                  "t": "m",
+                  "l": "pt",
+                  "k": "Comunica\u00e7\u00e3o eletr\u00f4nica",
+                  "_": "",
+                  "i": "1"
+              },
+              {
+                  "d": "nd",
+                  "_": "",
+                  "i": "2"
+              },
+              {
+                  "t": "m",
+                  "l": "en",
+                  "k": "Communication of knowledge",
+                  "_": "",
+                  "i": "2"
+              },
+              {
+                  "t": "m",
+                  "l": "en",
+                  "k": "Information flow",
+                  "_": "",
+                  "i": "2"
+              },
+              {
+                  "t": "m",
+                  "l": "en",
+                  "k": "Electronic communication",
+                  "_": "",
+                  "i": "2"
+              }
+          ],
+          "v999": [
+              {
+                  "_": "../bases-work/ci/ci"
+              }
+          ],
+          "v70": [
+              {
+                  "_": "Associa\u00e7\u00e3o Nacional de Pesquisa e P\u00f3s-Gradua\u00e7\u00e3o em Ci\u00eancia da Informa\u00e7\u00e3o, ANCIB",
+                  "i": "A01"
+              }
+          ],
+          "v706": [
+              {
+                  "_": "h"
+              }
+          ],
+          "v120": [
+              {
+                  "_": "2.0"
+              }
+          ],
+          "v121": [
+              {
+                  "_": "03"
+              }
+          ],
+          "processing_date": "2019-08-13",
+          "v42": [
+              {
+                  "_": "1"
+              }
+          ],
+          "v71": [
+              {
+                  "_": "oa"
+              }
+          ],
+          "v700": [
+              {
+                  "_": "2"
+              }
+          ],
+          "v992": [
+              {
+                  "_": "scl"
+              }
+          ],
+          "v936": [
+              {
+                  "_": "",
+                  "o": "2",
+                  "y": "1998",
+                  "i": "0100-1965"
+              }
+          ],
+          "v705": [
+              {
+                  "_": "S"
+              }
+          ],
+          "v14": [
+              {
+                  "f": "nd",
+                  "l": "nd",
+                  "_": ""
+              }
+          ],
+          "v38": [
+              {
+                  "_": "FIG"
+              },
+              {
+                  "_": "TAB"
+              }
+          ],
+          "v2": [
+              {
+                  "_": "S0100-1965(98)02700200003"
+              }
+          ],
+          "v32": [
+              {
+                  "_": "2"
+              }
+          ]
+      },
+      "normalized": {
+          "article": {
+              "v70": {
+                  "p": [
+                      true
+                  ]
+              }
+          }
+      },
+      "citations": [
+          {
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000300001"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19760000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200003"
+                  }
+              ],
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "1"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1976"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v16": [
+                  {
+                      "n": "P.",
+                      "r": "ND",
+                      "s": "RICOEUR",
+                      "_": ""
+                  }
+              ],
+              "v18": [
+                  {
+                      "l": "pt",
+                      "_": "Argumentos da teoria da interpreta\u00e7\u00e3o: o discurso e o exesso de significado"
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "Edi\u00e7\u00f5es 70"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "167"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "1"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "o": "2",
+                      "y": "1998",
+                      "i": "0100-1965"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "Lisboa"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "barreto.html"
+                  }
+              ],
+              "code": "S0100-1965199800020000300001",
+              "processing_date": "2019-08-17",
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "collection": "scl",
+              "v882": [
+                  {
+                      "n": "2",
+                      "v": "27",
+                      "_": ""
+                  }
+              ]
+          },
+          {
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000300002"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19840000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200003"
+                  }
+              ],
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "2"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1984"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v16": [
+                  {
+                      "n": "J.",
+                      "r": "ND",
+                      "s": "HABERMAS",
+                      "_": ""
+                  }
+              ],
+              "v18": [
+                  {
+                      "l": "pt",
+                      "_": "Mudan\u00e7a estrutural da esfera p\u00fablica."
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "Tempo Universit\u00e1rio"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "168"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "2"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "o": "2",
+                      "y": "1998",
+                      "i": "0100-1965"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "Rio de Janeiro"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "barreto.html"
+                  }
+              ],
+              "code": "S0100-1965199800020000300002",
+              "processing_date": "2019-08-17",
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "collection": "scl",
+              "v882": [
+                  {
+                      "n": "2",
+                      "v": "27",
+                      "_": ""
+                  }
+              ]
+          },
+          {
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000300003"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19800000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200003"
+                  }
+              ],
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "3"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1980"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v16": [
+                  {
+                      "n": "Y.",
+                      "r": "ND",
+                      "s": "MASUDA",
+                      "_": ""
+                  }
+              ],
+              "v18": [
+                  {
+                      "l": "pt",
+                      "_": "A sociedade da informa\u00e7\u00e3o."
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "Embratel"
+                  },
+                  {
+                      "_": "Editora Rio"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "169"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "3"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "o": "2",
+                      "y": "1998",
+                      "i": "0100-1965"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "Rio de Janeiro"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "barreto.html"
+                  }
+              ],
+              "code": "S0100-1965199800020000300003",
+              "processing_date": "2019-08-17",
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "collection": "scl",
+              "v882": [
+                  {
+                      "n": "2",
+                      "v": "27",
+                      "_": ""
+                  }
+              ]
+          },
+          {
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000300004"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19880000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200003"
+                  }
+              ],
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "4"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1988"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v16": [
+                  {
+                      "n": "C.",
+                      "r": "ND",
+                      "s": "RIZZINI",
+                      "_": ""
+                  }
+              ],
+              "v18": [
+                  {
+                      "l": "pt",
+                      "_": "O livro, o jornal e a tipografia no Brasil."
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "Imprensa Oficial do Estado"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "170"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "4"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "o": "2",
+                      "y": "1998",
+                      "i": "0100-1965"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "S\u00e3o Paulo"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "barreto.html"
+                  }
+              ],
+              "code": "S0100-1965199800020000300004",
+              "processing_date": "2019-08-17",
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "collection": "scl",
+              "v882": [
+                  {
+                      "n": "2",
+                      "v": "27",
+                      "_": ""
+                  }
+              ]
+          },
+          {
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000300005"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19450700"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+                  }
+              ],
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "5"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "July 1945"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v32": [
+                  {
+                      "_": "1"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v700": [
+                  {
+                      "_": "171"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "5"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "o": "2",
+                      "y": "1998",
+                      "i": "0100-1965"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v30": [
+                  {
+                      "_": "Atlantic Mountly"
+                  }
+              ],
+              "v710": [
+                  {
+                      "_": "2"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "barreto.html"
+                  }
+              ],
+              "v14": [
+                  {
+                      "_": "101-8"
+                  }
+              ],
+              "code": "S0100-1965199800020000300005",
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200003"
+                  }
+              ],
+              "collection": "scl",
+              "v882": [
+                  {
+                      "n": "2",
+                      "v": "27",
+                      "_": ""
+                  }
+              ],
+              "v10": [
+                  {
+                      "n": "Vanevar",
+                      "r": "ND",
+                      "s": "BUSH",
+                      "_": ""
+                  }
+              ],
+              "v12": [
+                  {
+                      "l": "en",
+                      "_": "As we may think"
+                  }
+              ]
+          },
+          {
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000300006"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19730000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200003"
+                  }
+              ],
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "6"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1973"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v16": [
+                  {
+                      "n": "R.",
+                      "r": "ND",
+                      "s": "BARTHES",
+                      "_": ""
+                  }
+              ],
+              "v18": [
+                  {
+                      "l": "pt",
+                      "_": "O prazer do texto."
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "Edi\u00e7\u00f5es 70"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "172"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "6"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "o": "2",
+                      "y": "1998",
+                      "i": "0100-1965"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "Lisboa"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "barreto.html"
+                  }
+              ],
+              "code": "S0100-1965199800020000300006",
+              "processing_date": "2019-08-17",
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "collection": "scl",
+              "v882": [
+                  {
+                      "n": "2",
+                      "v": "27",
+                      "_": ""
+                  }
+              ]
+          },
+          {
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000300007"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19840000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200003"
+                  }
+              ],
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "7"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1984"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v16": [
+                  {
+                      "n": "R.",
+                      "r": "ND",
+                      "s": "BARTHES",
+                      "_": ""
+                  }
+              ],
+              "v18": [
+                  {
+                      "l": "pt",
+                      "_": "O rumor da l\u00edngua."
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "Edi\u00e7\u00f5es 70"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "173"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "7"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "o": "2",
+                      "y": "1998",
+                      "i": "0100-1965"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "Lisboa"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "barreto.html"
+                  }
+              ],
+              "code": "S0100-1965199800020000300007",
+              "processing_date": "2019-08-17",
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "collection": "scl",
+              "v882": [
+                  {
+                      "n": "2",
+                      "v": "27",
+                      "_": ""
+                  }
+              ]
+          },
+          {
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000300008"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "8"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v35": [
+                  {
+                      "_": "0100-7157"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v61": [
+                  {
+                      "_": "no prelo"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "174"
+                  }
+              ],
+              "v882": [
+                  {
+                      "n": "2",
+                      "v": "27",
+                      "_": ""
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "8"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "o": "2",
+                      "y": "1998",
+                      "i": "0100-1965"
+                  }
+              ],
+              "v30": [
+                  {
+                      "_": "Revista de Biblioteconomia de Bras\u00edlia"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "barreto.html"
+                  }
+              ],
+              "v801": [
+                  {
+                      "_": "Revista de biblioteconomia de Bras\u00edlia"
+                  }
+              ],
+              "code": "S0100-1965199800020000300008",
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200003"
+                  }
+              ],
+              "collection": "scl",
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v10": [
+                  {
+                      "n": "A. de A.",
+                      "r": "ND",
+                      "s": "BARRETO",
+                      "_": ""
+                  }
+              ],
+              "v12": [
+                  {
+                      "l": "pt",
+                      "_": "Perspectivas da ci\u00eancia da informa\u00e7\u00e3o"
+                  }
+              ]
+          },
+          {
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000300009"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19940000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+                  }
+              ],
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "9"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v31": [
+                  {
+                      "_": "8"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1994"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v35": [
+                  {
+                      "_": "0102-8839"
+                  }
+              ],
+              "v32": [
+                  {
+                      "_": "4"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v700": [
+                  {
+                      "_": "175"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "9"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "o": "2",
+                      "y": "1998",
+                      "i": "0100-1965"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v30": [
+                  {
+                      "_": "S\u00e3o Paulo em Perspectiva"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "barreto.html"
+                  }
+              ],
+              "v14": [
+                  {
+                      "_": "3-8"
+                  }
+              ],
+              "v801": [
+                  {
+                      "_": "S\u00e3o Paulo em Perspectiva"
+                  }
+              ],
+              "code": "S0100-1965199800020000300009",
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200003"
+                  }
+              ],
+              "collection": "scl",
+              "v882": [
+                  {
+                      "n": "2",
+                      "v": "27",
+                      "_": ""
+                  }
+              ],
+              "v10": [
+                  {
+                      "n": "A. de A.",
+                      "r": "ND",
+                      "s": "BARRETO",
+                      "_": ""
+                  }
+              ],
+              "v12": [
+                  {
+                      "l": "pt",
+                      "_": "A quest\u00e3o da informa\u00e7\u00e3o"
+                  }
+              ]
+          },
+          {
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000300010"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19590000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200003"
+                  }
+              ],
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "10"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1959"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v16": [
+                  {
+                      "n": "C.",
+                      "r": "ND",
+                      "s": "GOYCOCHEA",
+                      "_": ""
+                  }
+              ],
+              "v18": [
+                  {
+                      "l": "pt",
+                      "_": "Filosofia das ci\u00eancias"
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "Freitas Bastos"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "176"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "10"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "o": "2",
+                      "y": "1998",
+                      "i": "0100-1965"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": ". Rio de Janeiro"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "barreto.html"
+                  }
+              ],
+              "code": "S0100-1965199800020000300010",
+              "processing_date": "2019-08-17",
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "collection": "scl",
+              "v882": [
+                  {
+                      "n": "2",
+                      "v": "27",
+                      "_": ""
+                  }
+              ]
+          },
+          {
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000300011"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19710000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200003"
+                  }
+              ],
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "11"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1971"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v16": [
+                  {
+                      "n": "C. W.",
+                      "r": "ND",
+                      "s": "HANSON",
+                      "_": ""
+                  }
+              ],
+              "v18": [
+                  {
+                      "l": "en",
+                      "_": "Introduction to science information work."
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "Aslib"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "177"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "11"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "o": "2",
+                      "y": "1998",
+                      "i": "0100-1965"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "London"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "barreto.html"
+                  }
+              ],
+              "code": "S0100-1965199800020000300011",
+              "processing_date": "2019-08-17",
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "collection": "scl",
+              "v882": [
+                  {
+                      "n": "2",
+                      "v": "27",
+                      "_": ""
+                  }
+              ]
+          },
+          {
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000300012"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19940000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200003"
+                  }
+              ],
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "12"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1994"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v16": [
+                  {
+                      "n": "P.",
+                      "r": "ND",
+                      "s": "LEVY",
+                      "_": ""
+                  }
+              ],
+              "v18": [
+                  {
+                      "l": "pt",
+                      "_": "A intelig\u00eancia colectiva: para uma antropologia do ciberespa\u00e7o."
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "Instituto Piaget"
+                  },
+                  {
+                      "_": "Epistemologia e Sociedade"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "178"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "12"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "o": "2",
+                      "y": "1998",
+                      "i": "0100-1965"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "Lisboa"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "barreto.html"
+                  }
+              ],
+              "code": "S0100-1965199800020000300012",
+              "processing_date": "2019-08-17",
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "collection": "scl",
+              "v882": [
+                  {
+                      "n": "2",
+                      "v": "27",
+                      "_": ""
+                  }
+              ]
+          },
+          {
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000300013"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19640000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200003"
+                  }
+              ],
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "13"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1964"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v63": [
+                  {
+                      "_": "5"
+                  }
+              ],
+              "v16": [
+                  {
+                      "n": "M.",
+                      "r": "ND",
+                      "s": "MCLUHAN",
+                      "_": ""
+                  }
+              ],
+              "v18": [
+                  {
+                      "l": "pt",
+                      "_": "Os meios de comunica\u00e7\u00e3o como extens\u00f5es do homem."
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "Cultrix"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "179"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "13"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "o": "2",
+                      "y": "1998",
+                      "i": "0100-1965"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "S\u00e3o Paulo"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "barreto.html"
+                  }
+              ],
+              "code": "S0100-1965199800020000300013",
+              "processing_date": "2019-08-17",
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "collection": "scl",
+              "v882": [
+                  {
+                      "n": "2",
+                      "v": "27",
+                      "_": ""
+                  }
+              ]
+          },
+          {
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000300014"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19950000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200003"
+                  }
+              ],
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "14"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1995"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v16": [
+                  {
+                      "n": "J.",
+                      "r": "ED",
+                      "s": "MEHELER",
+                      "_": ""
+                  }
+              ],
+              "v18": [
+                  {
+                      "l": "en",
+                      "_": "Cognition on cognition"
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "MIT Press"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "180"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "14"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "o": "2",
+                      "y": "1998",
+                      "i": "0100-1965"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "barreto.html"
+                  }
+              ],
+              "code": "S0100-1965199800020000300014",
+              "processing_date": "2019-08-17",
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "collection": "scl",
+              "v882": [
+                  {
+                      "n": "2",
+                      "v": "27",
+                      "_": ""
+                  }
+              ]
+          },
+          {
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000300015"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19900000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200003"
+                  }
+              ],
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "15"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1990"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v63": [
+                  {
+                      "_": "4"
+                  }
+              ],
+              "v16": [
+                  {
+                      "n": "P.",
+                      "r": "ND",
+                      "s": "RICOEUR",
+                      "_": ""
+                  }
+              ],
+              "v18": [
+                  {
+                      "l": "pt",
+                      "_": "Interpreta\u00e7\u00e3o e ideologias."
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "Francisco Alves"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "181"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "15"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "o": "2",
+                      "y": "1998",
+                      "i": "0100-1965"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "Rio de Janeiro"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "barreto.html"
+                  }
+              ],
+              "code": "S0100-1965199800020000300015",
+              "processing_date": "2019-08-17",
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "collection": "scl",
+              "v882": [
+                  {
+                      "n": "2",
+                      "v": "27",
+                      "_": ""
+                  }
+              ]
+          },
+          {
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000300016"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19--0000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+                  }
+              ],
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "16"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v31": [
+                  {
+                      "_": "4"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "19--"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v32": [
+                  {
+                      "_": "2"
+                  }
+              ],
+              "processing_date": "2019-08-17",
+              "v700": [
+                  {
+                      "_": "182"
+                  }
+              ],
+              "v882": [
+                  {
+                      "n": "2",
+                      "v": "27",
+                      "_": ""
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "16"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "o": "2",
+                      "y": "1998",
+                      "i": "0100-1965"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v30": [
+                  {
+                      "_": "SEHR"
+                  }
+              ],
+              "v710": [
+                  {
+                      "_": "2"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "barreto.html"
+                  }
+              ],
+              "v14": [
+                  {
+                      "_": "1-13"
+                  }
+              ],
+              "code": "S0100-1965199800020000300016",
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200003"
+                  }
+              ],
+              "collection": "scl",
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v10": [
+                  {
+                      "n": "G.",
+                      "r": "ND",
+                      "s": "TELL",
+                      "_": ""
+                  },
+                  {
+                      "n": "B.",
+                      "r": "ND",
+                      "s": "LATOUR",
+                      "_": ""
+                  }
+              ],
+              "v12": [
+                  {
+                      "l": "en",
+                      "_": "The hume machine: can association networks do more than formal rules?"
+                  }
+              ]
+          },
+          {
+              "v880": [
+                  {
+                      "_": "S0100-1965199800020000300017"
+                  }
+              ],
+              "v999": [
+                  {
+                      "_": "../bases-work/ci/ci"
+                  }
+              ],
+              "v65": [
+                  {
+                      "_": "19730000"
+                  }
+              ],
+              "v708": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v2": [
+                  {
+                      "_": "S0100-1965(98)02700200003"
+                  }
+              ],
+              "v709": [
+                  {
+                      "_": "article"
+                  }
+              ],
+              "v701": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v706": [
+                  {
+                      "_": "c"
+                  }
+              ],
+              "v64": [
+                  {
+                      "_": "1973"
+                  }
+              ],
+              "v4": [
+                  {
+                      "_": "v27n2"
+                  }
+              ],
+              "v16": [
+                  {
+                      "n": "B. C.",
+                      "r": "ND",
+                      "s": "VICKERY",
+                      "_": ""
+                  }
+              ],
+              "v18": [
+                  {
+                      "l": "en",
+                      "_": "Information systems"
+                  }
+              ],
+              "v62": [
+                  {
+                      "_": "Butterworths"
+                  }
+              ],
+              "v700": [
+                  {
+                      "_": "183"
+                  }
+              ],
+              "v992": [
+                  {
+                      "_": "scl"
+                  }
+              ],
+              "v118": [
+                  {
+                      "_": "17"
+                  }
+              ],
+              "v705": [
+                  {
+                      "_": "S"
+                  }
+              ],
+              "v936": [
+                  {
+                      "_": "",
+                      "o": "2",
+                      "y": "1998",
+                      "i": "0100-1965"
+                  }
+              ],
+              "v66": [
+                  {
+                      "_": "London"
+                  }
+              ],
+              "v702": [
+                  {
+                      "_": "V:\\Scielo\\serial\\ci\\v27n2\\markup\\barreto.html"
+                  }
+              ],
+              "v3": [
+                  {
+                      "_": "barreto.html"
+                  }
+              ],
+              "code": "S0100-1965199800020000300017",
+              "processing_date": "2019-08-17",
+              "v865": [
+                  {
+                      "_": "19980000"
+                  }
+              ],
+              "collection": "scl",
+              "v882": [
+                  {
+                      "n": "2",
+                      "v": "27",
+                      "_": ""
+                  }
+              ]
+          }
+      ],
+      "validated_scielo": "False"
+  }
+]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,3 +12,8 @@ class ConfigTest(TestCase):
         self.assertEqual(
             config.get("DOAJ_API_URL"), config._default.get("DOAJ_API_URL")
         )
+
+    def test_get_default_export_run_retries_if_no_envvar_set(self):
+        self.assertEqual(
+            config.get("EXPORT_RUN_RETRIES"), config._default.get("EXPORT_RUN_RETRIES")
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,14 @@
+from unittest import TestCase, mock
+
+from exporter import config
+
+
+class ConfigTest(TestCase):
+    @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
+    def test_get_doaj_api_key(self):
+        self.assertEqual(config.get("DOAJ_API_KEY"), "doaj-api-key-1234")
+
+    def test_get_default_doaj_api_url_if_no_envvar_set(self):
+        self.assertEqual(
+            config.get("DOAJ_API_URL"), config._default.get("DOAJ_API_URL")
+        )

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -138,6 +138,12 @@ class DOAJExporterXyloseArticleTest(TestCase):
             expected, self.doaj_document.post_request
         )
 
+    def test_get_request(self):
+        expected = { "params": { "api_key": config.get("DOAJ_API_KEY") } }
+        self.assertEqual(
+            expected, self.doaj_document.get_request
+        )
+
     def test_post_response_201(self):
         fake_response = {
           "id": "doaj-1234",

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -82,6 +82,15 @@ class DOAJExporterXyloseArticleTest(TestCase):
 
         self.assertEqual(expected, self.doaj_document.bibjson_journal)
 
+    def test_bibjson_keywords(self):
+        keywords = self.article.keywords()
+        expected = []
+        for kw_lang in keywords.values():
+            expected += kw_lang
+        self.assertEqual(
+            expected, self.doaj_document.bibjson_keywords
+        )
+
     def test_bibjson_title(self):
         title = self.article.original_title()
         if (
@@ -171,6 +180,12 @@ class DOAJExporterXyloseArticleExceptionsTest(TestCase):
             doaj.DOAJExporterXyloseArticleNoJournalRequiredFields
         ) as exc:
             doaj.DOAJExporterXyloseArticle(article=self.article)
+
+    def test_no_keywords_if_no_article_keywords(self):
+        del self.article.data["article"]["v85"]    # v85: keywords
+        doaj_document = doaj.DOAJExporterXyloseArticle(article=self.article)
+
+        self.assertIsNone(doaj_document.bibjson_keywords)
 
     def test_sets_as_untitled_document_if_no_article_title(self):
         del self.article.data["article"]["v12"]    # v12: titles

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -70,6 +70,31 @@ class DOAJExporterXyloseArticleTest(TestCase):
             expected, self.doaj_document.post_request
         )
 
+    def test_post_response_201(self):
+        fake_response = {
+          "id": "doaj-1234",
+          "location": "",
+          "status": "OK",
+        }
+        expected = {
+            "index_id": "doaj-1234",
+            "status": "OK",
+        }
+        self.assertEqual(
+            expected, self.doaj_document.post_response(fake_response)
+        )
+
+    def test_error_response(self):
+        fake_response = {
+          "id": "doaj-1234",
+          "location": "",
+          "status": "FAIL",
+          "error": "Fake Field is missing.",
+        }
+        self.assertEqual(
+            "Fake Field is missing.", self.doaj_document.error_response(fake_response)
+        )
+
 
 @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
 class DOAJExporterXyloseArticleExceptionsTest(TestCase):
@@ -111,4 +136,15 @@ class DOAJExporterXyloseArticleExceptionsTest(TestCase):
         self.assertEqual(
             self.article.issue.sections.get(section_code, {}).get(original_lang),
             doaj_document.bibjson_title,
+        )
+
+    def test_error_response_return_empty_str_if_no_error(self):
+        doaj_document = doaj.DOAJExporterXyloseArticle(article=self.article)
+        fake_response = {
+          "id": "doaj-1234",
+          "location": "",
+          "status": "FAIL",
+        }
+        self.assertEqual(
+            "", doaj_document.error_response(fake_response)
         )

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -23,7 +23,9 @@ class DOAJExporterXyloseArticleTest(TestCase):
     def test_bibjson_author(self):
         for author in self.article.authors:
             with self.subTest(author=author):
-                author_name = [author.get('given_names', ''), author.get('surname', '')]
+                author_name = " ".join(
+                    [author.get('given_names', ''), author.get('surname', '')]
+                )
                 self.assertIn(
                     {"name": author_name},
                     self.doaj_document.bibjson_author,

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -114,17 +114,8 @@ class DOAJExporterXyloseArticleTest(TestCase):
         )
 
     def test_bibjson_title(self):
-        title = self.article.original_title()
-        if (
-            not title and
-            self.article.translated_titles() and
-            len(self.article.translated_titles()) != 0
-        ):
-            item = [(k, v) for k, v in self.article.translated_titles().items()][0]
-            title = item[1]
-
         self.assertEqual(
-            title, self.doaj_document.bibjson_title
+            self.article.original_title(), self.doaj_document.bibjson_title
         )
 
     def test_post_request(self):

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -98,6 +98,12 @@ class DOAJExporterXyloseArticleTest(TestCase):
 
 
 class PostDOAJExporterXyloseArticleTest(DOAJExporterXyloseArticleTest):
+    def test_id(self):
+        self.assertEqual(
+            self.article.data["doaj_id"],
+            self.doaj_document.id,
+        )
+
     def test_crud_article_put_url(self):
         self.assertEqual(
             config.get("DOAJ_API_URL") + "articles",
@@ -165,6 +171,12 @@ class PostDOAJExporterXyloseArticleTest(DOAJExporterXyloseArticleTest):
 
 
 class PutDOAJExporterXyloseArticleTest(DOAJExporterXyloseArticleTest):
+    def test_id(self):
+        self.assertEqual(
+            self.article.data["doaj_id"],
+            self.doaj_document.id,
+        )
+
     def test_crud_article_url(self):
         self.assertEqual(
             config.get("DOAJ_API_URL") + "articles/" + self.article.data["doaj_id"],
@@ -220,6 +232,12 @@ class PutDOAJExporterXyloseArticleTest(DOAJExporterXyloseArticleTest):
 
 
 class DeleteDOAJExporterXyloseArticleTest(DOAJExporterXyloseArticleTest):
+    def test_id(self):
+        self.assertEqual(
+            self.article.data["doaj_id"],
+            self.doaj_document.id,
+        )
+
     def test_crud_article_url(self):
         self.assertEqual(
             config.get("DOAJ_API_URL") + "articles/" + self.article.data["doaj_id"],

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -12,12 +12,29 @@ class DOAJExporterXyloseArticleTest(TestCase):
     def setUp(self):
         client = AMClient()
         self.article = client.document(collection="scl", pid="S0100-19651998000200002")
-        self.doaj_document = doaj.DOAJExporterXyloseArticle(article=self.article)
+        self.doaj_document = doaj.DOAJExporterXyloseArticle(
+            article=self.article, now=self._fake_utcnow()
+        )
+
+    def _fake_utcnow(self):
+        return "2021-01-01T00:00:00Z"
 
     def test_crud_article_url(self):
         self.assertEqual(
             config.get("DOAJ_API_URL") + "articles",
             self.doaj_document.crud_article_url,
+        )
+
+    def test_created_date(self):
+        self.assertEqual(
+            self._fake_utcnow(),
+            self.doaj_document.created_date,
+        )
+
+    def test_last_updated(self):
+        self.assertEqual(
+            self._fake_utcnow(),
+            self.doaj_document.last_updated,
         )
 
     def test_bibjson_author(self):

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -38,6 +38,12 @@ class DOAJExporterXyloseArticleTest(TestCase):
             self.doaj_document.last_updated,
         )
 
+    def test_bibjson_abstract(self):
+        abstract = self.article.original_abstract()
+        self.assertEqual(
+            abstract, self.doaj_document.bibjson_abstract
+        )
+
     def test_bibjson_author(self):
         for author in self.article.authors:
             with self.subTest(author=author):
@@ -169,6 +175,12 @@ class DOAJExporterXyloseArticleExceptionsTest(TestCase):
         with self.assertRaises(doaj.DOAJExporterXyloseArticleNoRequestData) as exc:
             doaj.DOAJExporterXyloseArticle(article=self.article)._api_key
         self.assertEqual("No DOAJ_API_KEY set", str(exc.exception))
+
+    def test_no_abstract_if_no_article_abstract(self):
+        del self.article.data["article"]["v83"]    # v83: abstract
+        doaj_document = doaj.DOAJExporterXyloseArticle(article=self.article)
+
+        self.assertIsNone(doaj_document.bibjson_abstract)
 
     def test_raises_exception_if_no_author(self):
         del self.article.data["article"]["v10"]    # v10: authors

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -85,9 +85,7 @@ class DOAJExporterXyloseArticleTest(TestCase):
 
     def test_bibjson_keywords(self):
         keywords = self.article.keywords()
-        expected = []
-        for kw_lang in keywords.values():
-            expected += kw_lang
+        expected = keywords.get(self.article.original_language())
         self.assertEqual(
             expected, self.doaj_document.bibjson_keywords
         )

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -207,6 +207,20 @@ class PutDOAJExporterXyloseArticleTest(DOAJExporterXyloseArticleTest):
         )
 
 
+class DeleteDOAJExporterXyloseArticleTest(DOAJExporterXyloseArticleTest):
+    def test_crud_article_url(self):
+        self.assertEqual(
+            config.get("DOAJ_API_URL") + "articles/" + self.article.data["doaj_id"],
+            self.doaj_document.crud_article_url,
+        )
+
+    def test_delete_request(self):
+        expected = { "params": { "api_key": config.get("DOAJ_API_KEY") } }
+        self.assertEqual(
+            expected, self.doaj_document.delete_request
+        )
+
+
 @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
 class DOAJExporterXyloseArticleExceptionsTestMixin:
     @mock.patch.dict("os.environ", {"DOAJ_API_URL": ""})

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -59,8 +59,14 @@ class DOAJExporterXyloseArticleTest(TestCase):
             title, self.doaj_document.bibjson_title
         )
 
-    def test_export(self):
-        pass
+    def test_post_request(self):
+        expected = {
+            "api_key": config.get("DOAJ_API_KEY"),
+            "article_json": self.doaj_document._data
+        }
+        self.assertEqual(
+            expected, self.doaj_document.post_request
+        )
 
 
 @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -98,8 +98,8 @@ class DOAJExporterXyloseArticleTest(TestCase):
 
     def test_post_request(self):
         expected = {
-            "api_key": config.get("DOAJ_API_KEY"),
-            "article_json": self.doaj_document._data
+            "params": {"api_key": config.get("DOAJ_API_KEY")},
+            "json": self.doaj_document._data,
         }
         self.assertEqual(
             expected, self.doaj_document.post_request

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -122,22 +122,25 @@ class PostDOAJExporterXyloseArticleTest(DOAJExporterXyloseArticleTest):
             self.doaj_document.bulk_articles_url,
         )
 
+    def test_params_request(self):
+        self.assertEqual(
+            self.doaj_document.params_request,
+            {"api_key": config.get("DOAJ_API_KEY")},
+        )
+
     def test_post_request(self):
         expected = {
-            "params": {"api_key": config.get("DOAJ_API_KEY")},
-            "json": {
-                "id": self.article.data["doaj_id"],
-                "created_date": self._expected_created_date(),
-                "last_updated": self._expected_last_updated(),
-                "bibjson": {
-                    "abstract": self._expected_bibjson_abstract(),
-                    "author": self._expected_bibjson_author(),
-                    "identifier": self._expected_bibjson_identifier(),
-                    "journal": self._expected_bibjson_journal(),
-                    "keywords": self._expected_bibjson_keywords(),
-                    "link": self._expected_bibjson_link(),
-                    "title": self._expected_bibjson_title(),
-                },
+            "id": self.article.data["doaj_id"],
+            "created_date": self._expected_created_date(),
+            "last_updated": self._expected_last_updated(),
+            "bibjson": {
+                "abstract": self._expected_bibjson_abstract(),
+                "author": self._expected_bibjson_author(),
+                "identifier": self._expected_bibjson_identifier(),
+                "journal": self._expected_bibjson_journal(),
+                "keywords": self._expected_bibjson_keywords(),
+                "link": self._expected_bibjson_link(),
+                "title": self._expected_bibjson_title(),
             },
         }
         self.assertEqual(
@@ -183,10 +186,10 @@ class PutDOAJExporterXyloseArticleTest(DOAJExporterXyloseArticleTest):
             self.doaj_document.crud_article_url,
         )
 
-    def test_get_request(self):
-        expected = { "params": { "api_key": config.get("DOAJ_API_KEY") } }
+    def test_params_request(self):
         self.assertEqual(
-            expected, self.doaj_document.get_request
+            self.doaj_document.params_request,
+            {"api_key": config.get("DOAJ_API_KEY")},
         )
 
     def test_put_request(self):
@@ -210,20 +213,17 @@ class PutDOAJExporterXyloseArticleTest(DOAJExporterXyloseArticleTest):
             },
         }
         expected = {
-            "params": {"api_key": config.get("DOAJ_API_KEY")},
-            "json": {
-                "id": self.article.data["doaj_id"],
-                "created_date": "2020-01-01T00:00:00Z",
-                "last_updated": self._expected_last_updated(),
-                "bibjson": {
-                    "abstract": self._expected_bibjson_abstract(),
-                    "author": self._expected_bibjson_author(),
-                    "identifier": self._expected_bibjson_identifier(),
-                    "journal": self._expected_bibjson_journal(),
-                    "keywords": self._expected_bibjson_keywords(),
-                    "link": self._expected_bibjson_link(),
-                    "title": self._expected_bibjson_title(),
-                },
+            "id": self.article.data["doaj_id"],
+            "created_date": "2020-01-01T00:00:00Z",
+            "last_updated": self._expected_last_updated(),
+            "bibjson": {
+                "abstract": self._expected_bibjson_abstract(),
+                "author": self._expected_bibjson_author(),
+                "identifier": self._expected_bibjson_identifier(),
+                "journal": self._expected_bibjson_journal(),
+                "keywords": self._expected_bibjson_keywords(),
+                "link": self._expected_bibjson_link(),
+                "title": self._expected_bibjson_title(),
             },
         }
         self.assertEqual(
@@ -244,10 +244,10 @@ class DeleteDOAJExporterXyloseArticleTest(DOAJExporterXyloseArticleTest):
             self.doaj_document.crud_article_url,
         )
 
-    def test_delete_request(self):
-        expected = { "params": { "api_key": config.get("DOAJ_API_KEY") } }
+    def test_params_request(self):
         self.assertEqual(
-            expected, self.doaj_document.delete_request
+            self.doaj_document.params_request,
+            {"api_key": config.get("DOAJ_API_KEY")},
         )
 
 
@@ -275,7 +275,7 @@ class DOAJExporterXyloseArticleExceptionsTestMixin:
         del self.article.data["article"]["v83"]    # v83: abstract
         self.doaj_document = doaj.DOAJExporterXyloseArticle(article=self.article)
         req = self.http_request_function()
-        self.assertIsNone(req["json"]["bibjson"].get("abstract"))
+        self.assertIsNone(req["bibjson"].get("abstract"))
 
     def test_http_request_raises_exception_if_no_author(self):
         del self.article.data["article"]["v10"]    # v10: authors
@@ -329,7 +329,7 @@ class DOAJExporterXyloseArticleExceptionsTestMixin:
         req = self.http_request_function()
         self.assertIn(
             {"id": "eissn-returned", "type": "eissn"},
-            req["json"]["bibjson"]["identifier"],
+            req["bibjson"]["identifier"],
         )
 
     def test_http_request_raises_exception_if_no_journal_required_fields(self):
@@ -348,7 +348,7 @@ class DOAJExporterXyloseArticleExceptionsTestMixin:
         del self.article.data["article"]["v85"]    # v85: keywords
         self.doaj_document = doaj.DOAJExporterXyloseArticle(article=self.article)
         req = self.http_request_function()
-        self.assertIsNone(req["json"]["bibjson"].get("keywords"))
+        self.assertIsNone(req["bibjson"].get("keywords"))
 
     def test_http_request_raises_exception_if_no_doi_nor_fulltexts(self):
         del self.article.data["doi"]
@@ -378,7 +378,7 @@ class DOAJExporterXyloseArticleExceptionsTestMixin:
         req = self.http_request_function()
         self.assertEqual(
             self.article.issue.sections.get(section_code, {}).get(original_lang),
-            req["json"]["bibjson"]["title"],
+            req["bibjson"]["title"],
         )
 
     def test_error_response_return_empty_str_if_no_error(self):

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -3,15 +3,22 @@ from unittest import TestCase, mock
 import vcr
 from xylose import scielodocument
 
-from exporter import AMClient, doaj
+from exporter import AMClient, doaj, config
 
 
 class DOAJExporterXyloseArticleTest(TestCase):
     @vcr.use_cassette("tests/fixtures/vcr_cassettes/S0100-19651998000200002.yml")
+    @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
     def setUp(self):
         client = AMClient()
         self.article = client.document(collection="scl", pid="S0100-19651998000200002")
         self.doaj_document = doaj.DOAJExporterXyloseArticle(article=self.article)
+
+    def test_crud_article_url(self):
+        self.assertEqual(
+            config.get("DOAJ_API_URL") + "articles",
+            self.doaj_document.crud_article_url,
+        )
 
     def test_bibjson_author(self):
         for author in self.article.authors:
@@ -56,11 +63,24 @@ class DOAJExporterXyloseArticleTest(TestCase):
         pass
 
 
+@mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
 class DOAJExporterXyloseArticleExceptionsTest(TestCase):
     @vcr.use_cassette("tests/fixtures/vcr_cassettes/S0100-19651998000200002.yml")
     def setUp(self):
         client = AMClient()
         self.article = client.document(collection="scl", pid="S0100-19651998000200002")
+
+    @mock.patch.dict("os.environ", {"DOAJ_API_URL": ""})
+    def test_raises_exception_if_no_post_url(self):
+        with self.assertRaises(doaj.DOAJExporterXyloseArticleNoRequestData) as exc:
+            doaj.DOAJExporterXyloseArticle(article=self.article).post_url
+        self.assertEqual("No DOAJ_API_URL set", str(exc.exception))
+
+    @mock.patch.dict("os.environ", {"DOAJ_API_KEY": ""})
+    def test_raises_exception_if_no_api_key(self):
+        with self.assertRaises(doaj.DOAJExporterXyloseArticleNoRequestData) as exc:
+            doaj.DOAJExporterXyloseArticle(article=self.article)._api_key
+        self.assertEqual("No DOAJ_API_KEY set", str(exc.exception))
 
     def test_raises_exception_if_no_author(self):
         del self.article.data["article"]["v10"]    # v10: authors

--- a/tests/test_doaj.py
+++ b/tests/test_doaj.py
@@ -104,6 +104,18 @@ class PostDOAJExporterXyloseArticleTest(DOAJExporterXyloseArticleTest):
             self.doaj_document.crud_article_put_url,
         )
 
+    def test_search_journal_url(self):
+        self.assertEqual(
+            config.get("DOAJ_API_URL") + "search/journals/",
+            self.doaj_document.search_journal_url,
+        )
+
+    def test_bulk_articles_url(self):
+        self.assertEqual(
+            config.get("DOAJ_API_URL") + "bulk/articles",
+            self.doaj_document.bulk_articles_url,
+        )
+
     def test_post_request(self):
         expected = {
             "params": {"api_key": config.get("DOAJ_API_KEY")},

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -667,7 +667,7 @@ class ProcessExtractedDocumentsTestMixin:
                 pids_by_collection={"scl": ["S0100-19651998000200001"]},
             )
             mk_logger_error.assert_called_once_with(
-                "Não foi possível exportar documento '%s': '%s'.",
+                "Não foi possível processar documento '%s': '%s'.",
                 "S0100-19651998000200001",
                 exc
             )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -475,6 +475,31 @@ class ArticleMetaParserTest(TestCase):
 
 class MainExporterTest(TestCase):
     @mock.patch("exporter.main.extract_and_export_documents")
+    def test_raises_exception_if_no_index_command(
+        self, mk_extract_and_export_documents
+    ):
+        with self.assertRaises(SystemExit) as exc:
+            main_exporter(
+                [
+                    "--output",
+                    "output.log",
+                ]
+            )
+
+    @mock.patch("exporter.main.extract_and_export_documents")
+    def test_raises_exception_if_no_doaj_command(
+        self, mk_extract_and_export_documents
+    ):
+        with self.assertRaises(SystemExit) as exc:
+            main_exporter(
+                [
+                    "--output",
+                    "output.log",
+                    "doaj",
+                ]
+            )
+
+    @mock.patch("exporter.main.extract_and_export_documents")
     def test_raises_exception_if_no_dates_nor_pids(
         self, mk_extract_and_export_documents
     ):
@@ -484,6 +509,7 @@ class MainExporterTest(TestCase):
                     "--output",
                     "output.log",
                     "doaj",
+                    "export",
                 ]
             )
         self.assertEqual(
@@ -501,6 +527,7 @@ class MainExporterTest(TestCase):
                     "--output",
                     "output.log",
                     "doaj",
+                    "export",
                     "--pid",
                     "S0100-19651998000200002",
                 ]
@@ -528,6 +555,7 @@ class MainExporterTest(TestCase):
                         "--output",
                         "output.log",
                         "doaj",
+                        "export",
                         "--pids",
                         str(pids_file),
                     ]
@@ -545,6 +573,7 @@ class MainExporterTest(TestCase):
                 "--output",
                 "output.log",
                 "doaj",
+                "export",
                 "--connection",
                 "thrift",
                 "--collection",
@@ -565,6 +594,7 @@ class MainExporterTest(TestCase):
                 "--output",
                 "output.log",
                 "doaj",
+                "export",
                 "--domain",
                 "http://anotheram.scielo.org",
                 "--collection",
@@ -585,6 +615,7 @@ class MainExporterTest(TestCase):
                 "--output",
                 "output.log",
                 "doaj",
+                "export",
                 "--collection",
                 "spa",
                 "--pid",
@@ -616,6 +647,7 @@ class MainExporterTest(TestCase):
                     "--output",
                     "output.log",
                     "doaj",
+                    "export",
                     "--collection",
                     "spa",
                     "--pids",
@@ -650,6 +682,7 @@ class MainExporterTest(TestCase):
                     "--output",
                     "output.log",
                     "doaj",
+                    "export",
                 ] +
                 args
             )
@@ -695,6 +728,7 @@ class MainExporterTest(TestCase):
                         "--output",
                         "output.log",
                         "doaj",
+                        "export",
                     ] +
                     args
                 )
@@ -731,6 +765,7 @@ class MainExporterTest(TestCase):
                 "--output",
                 "output.log",
                 "doaj",
+                "export",
                 "--from-date",
                 "01-01-2021",
                 "--until-date",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -473,7 +473,7 @@ class ArticleMetaParserTest(TestCase):
         self.assertEqual(str(args.domain), "http://anotheram.scielo.org")
 
 
-class MainExporterTest(TestCase):
+class MainExporterTestMixin:
     @mock.patch("exporter.main.extract_and_export_documents")
     def test_raises_exception_if_no_index_command(
         self, mk_extract_and_export_documents
@@ -495,7 +495,7 @@ class MainExporterTest(TestCase):
                 [
                     "--output",
                     "output.log",
-                    "doaj",
+                    self.index,
                 ]
             )
 
@@ -508,8 +508,8 @@ class MainExporterTest(TestCase):
                 [
                     "--output",
                     "output.log",
-                    "doaj",
-                    "export",
+                    self.index,
+                    self.index_command,
                 ]
             )
         self.assertEqual(
@@ -526,8 +526,8 @@ class MainExporterTest(TestCase):
                 [
                     "--output",
                     "output.log",
-                    "doaj",
-                    "export",
+                    self.index,
+                    self.index_command,
                     "--pid",
                     "S0100-19651998000200002",
                 ]
@@ -554,8 +554,8 @@ class MainExporterTest(TestCase):
                     [
                         "--output",
                         "output.log",
-                        "doaj",
-                        "export",
+                        self.index,
+                        self.index_command,
                         "--pids",
                         str(pids_file),
                     ]
@@ -572,8 +572,8 @@ class MainExporterTest(TestCase):
             [
                 "--output",
                 "output.log",
-                "doaj",
-                "export",
+                self.index,
+                self.index_command,
                 "--connection",
                 "thrift",
                 "--collection",
@@ -593,8 +593,8 @@ class MainExporterTest(TestCase):
             [
                 "--output",
                 "output.log",
-                "doaj",
-                "export",
+                self.index,
+                self.index_command,
                 "--domain",
                 "http://anotheram.scielo.org",
                 "--collection",
@@ -614,8 +614,8 @@ class MainExporterTest(TestCase):
             [
                 "--output",
                 "output.log",
-                "doaj",
-                "export",
+                self.index,
+                self.index_command,
                 "--collection",
                 "spa",
                 "--pid",
@@ -624,7 +624,7 @@ class MainExporterTest(TestCase):
         )
         mk_extract_and_export_documents.assert_called_with(
             get_document=mk_document,
-            index="doaj",
+            index=self.index,
             output_path=pathlib.Path("output.log"),
             pids_by_collection={"spa": ["S0100-19651998000200002"]},
         )
@@ -646,8 +646,8 @@ class MainExporterTest(TestCase):
                 [
                     "--output",
                     "output.log",
-                    "doaj",
-                    "export",
+                    self.index,
+                    self.index_command,
                     "--collection",
                     "spa",
                     "--pids",
@@ -656,7 +656,7 @@ class MainExporterTest(TestCase):
             )
         mk_extract_and_export_documents.assert_called_with(
             get_document=mk_document,
-            index="doaj",
+            index=self.index,
             output_path=pathlib.Path("output.log"),
             pids_by_collection={"spa": pids},
         )
@@ -681,8 +681,8 @@ class MainExporterTest(TestCase):
                 [
                     "--output",
                     "output.log",
-                    "doaj",
-                    "export",
+                    self.index,
+                    self.index_command,
                 ] +
                 args
             )
@@ -727,8 +727,8 @@ class MainExporterTest(TestCase):
                     [
                         "--output",
                         "output.log",
-                        "doaj",
-                        "export",
+                        self.index,
+                        self.index_command,
                     ] +
                     args
                 )
@@ -764,8 +764,8 @@ class MainExporterTest(TestCase):
             [
                 "--output",
                 "output.log",
-                "doaj",
-                "export",
+                self.index,
+                self.index_command,
                 "--from-date",
                 "01-01-2021",
                 "--until-date",
@@ -774,7 +774,7 @@ class MainExporterTest(TestCase):
         )
         mk_extract_and_export_documents.assert_called_once_with(
             get_document=mk_document,
-            index="doaj",
+            index=self.index,
             output_path=pathlib.Path("output.log"),
             pids_by_collection={
                 "scl": ["S0101-01019000090090097"],
@@ -782,3 +782,8 @@ class MainExporterTest(TestCase):
                 "cub": ["S0303-01019000090090099"],
             },
         )
+
+
+class DOAJExportMainExporterTest(MainExporterTestMixin, TestCase):
+    index = "doaj"
+    index_command = "export"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 import tempfile
 import pathlib
 import json
+import shutil
 from unittest import TestCase, mock
 from datetime import datetime, timedelta
 
@@ -712,7 +713,7 @@ class MainExporterTestMixin:
             main_exporter(
                 [
                     "--output",
-                    "output.log",
+                    str(self.output_path),
                 ]
             )
 
@@ -724,7 +725,7 @@ class MainExporterTestMixin:
             main_exporter(
                 [
                     "--output",
-                    "output.log",
+                    str(self.output_path),
                     self.index,
                 ]
             )
@@ -737,7 +738,7 @@ class MainExporterTestMixin:
             main_exporter(
                 [
                     "--output",
-                    "output.log",
+                    str(self.output_path),
                     self.index,
                     self.index_command,
                 ]
@@ -755,7 +756,7 @@ class MainExporterTestMixin:
             main_exporter(
                 [
                     "--output",
-                    "output.log",
+                    str(self.output_path),
                     self.index,
                     self.index_command,
                     "--pid",
@@ -783,7 +784,7 @@ class MainExporterTestMixin:
                 main_exporter(
                     [
                         "--output",
-                        "output.log",
+                        str(self.output_path),
                         self.index,
                         self.index_command,
                         "--pids",
@@ -801,7 +802,7 @@ class MainExporterTestMixin:
         main_exporter(
             [
                 "--output",
-                "output.log",
+                str(self.output_path),
                 self.index,
                 self.index_command,
                 "--connection",
@@ -822,7 +823,7 @@ class MainExporterTestMixin:
         main_exporter(
             [
                 "--output",
-                "output.log",
+                str(self.output_path),
                 self.index,
                 self.index_command,
                 "--domain",
@@ -843,7 +844,7 @@ class MainExporterTestMixin:
         main_exporter(
             [
                 "--output",
-                "output.log",
+                str(self.output_path),
                 self.index,
                 self.index_command,
                 "--collection",
@@ -856,7 +857,7 @@ class MainExporterTestMixin:
             get_document=mk_document,
             index=self.index,
             index_command=self.index_command,
-            output_path=pathlib.Path("output.log"),
+            output_path=self.output_path,
             pids_by_collection={"spa": ["S0100-19651998000200002"]},
         )
 
@@ -876,7 +877,7 @@ class MainExporterTestMixin:
             main_exporter(
                 [
                     "--output",
-                    "output.log",
+                    str(self.output_path),
                     self.index,
                     self.index_command,
                     "--collection",
@@ -889,7 +890,7 @@ class MainExporterTestMixin:
             get_document=mk_document,
             index=self.index,
             index_command=self.index_command,
-            output_path=pathlib.Path("output.log"),
+            output_path=self.output_path,
             pids_by_collection={"spa": pids},
         )
 
@@ -912,7 +913,7 @@ class MainExporterTestMixin:
             main_exporter(
                 [
                     "--output",
-                    "output.log",
+                    str(self.output_path),
                     self.index,
                     self.index_command,
                 ] +
@@ -958,7 +959,7 @@ class MainExporterTestMixin:
                 main_exporter(
                     [
                         "--output",
-                        "output.log",
+                        str(self.output_path),
                         self.index,
                         self.index_command,
                     ] +
@@ -995,7 +996,7 @@ class MainExporterTestMixin:
         main_exporter(
             [
                 "--output",
-                "output.log",
+                str(self.output_path),
                 self.index,
                 self.index_command,
                 "--from-date",
@@ -1008,7 +1009,7 @@ class MainExporterTestMixin:
             get_document=mk_document,
             index=self.index,
             index_command=self.index_command,
-            output_path=pathlib.Path("output.log"),
+            output_path=self.output_path,
             pids_by_collection={
                 "scl": ["S0101-01019000090090097"],
                 "arg": ["S0202-01019000090090098"],
@@ -1020,8 +1021,21 @@ class MainExporterTestMixin:
 class DOAJExportMainExporterTest(MainExporterTestMixin, TestCase):
     index = "doaj"
     index_command = "export"
+    output_path = pathlib.Path("output.log")
 
 
 class DOAJUpdateMainExporterTest(MainExporterTestMixin, TestCase):
     index = "doaj"
     index_command = "update"
+    output_path = pathlib.Path("output.log")
+
+
+class DOAJGetMainExporterTest(MainExporterTestMixin, TestCase):
+    index = "doaj"
+    index_command = "get"
+
+    def setUp(self):
+        self.output_path = pathlib.Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.output_path)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -152,20 +152,15 @@ class ExportXyloseArticleExporterAdapterTest(
             "exporter.doaj.DOAJExporterXyloseArticle.post_request",
             new_callable=mock.PropertyMock,
         ) as mk_post_request:
-            mk_post_request.return_value = {
-                "params": {"api_key": "doaj-api-key-1234"},
-                "json": {"field": "value"},
-            }
+            mk_post_request.return_value = {"field": "value"}
             article_exporter = XyloseArticleExporterAdapter(
                 index=self.index, command=self.index_command, article=self.article,
             )
             article_exporter.command_function()
             mk_requests.post.assert_called_once_with(
                 url=article_exporter.index_exporter.crud_article_put_url,
-                **{
-                    "params": {"api_key": "doaj-api-key-1234"},
-                    "json": {"field": "value"},
-                },
+                params=article_exporter.index_exporter.params_request,
+                json={"field": "value"},
             )
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
@@ -226,14 +221,9 @@ class UpdateXyloseArticleExporterAdapterTest(
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
     @mock.patch("exporter.main.requests")
-    @mock.patch(
-        "exporter.main.doaj.DOAJExporterXyloseArticle.get_request",
-        new_callable=mock.PropertyMock,
-    )
     def test_update_calls_requests_get_to_doaj_api_with_doaj_get_request(
-        self, mk_get_request, mk_requests
+        self, mk_requests
     ):
-        mk_get_request.return_value = { "params": {"api_key": "doaj-api-key-1234"} }
         article_exporter = XyloseArticleExporterAdapter(
             index=self.index, command=self.index_command, article=self.article
         )
@@ -242,7 +232,7 @@ class UpdateXyloseArticleExporterAdapterTest(
         article_exporter.command_function()
         mk_requests.get.assert_called_once_with(
             url=crud_article_url,
-            **{ "params": { "api_key": "doaj-api-key-1234" } },
+            params=article_exporter.params_request,
         )
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
@@ -296,11 +286,8 @@ class UpdateXyloseArticleExporterAdapterTest(
         mock_resp = mock.Mock()
         mk_requests.get.return_value = mk_requests.put.return_value = mock_resp
         mk_put_request.return_value = {
-            "params": {"api_key": "doaj-api-key-1234"},
-            "json": {
-                "id": "doaj-id",
-                "field": "value",
-            }
+            "id": "doaj-id",
+            "field": "value",
         }
 
         article_exporter = XyloseArticleExporterAdapter(
@@ -311,12 +298,10 @@ class UpdateXyloseArticleExporterAdapterTest(
         article_exporter.command_function()
         mk_requests.put.assert_called_once_with(
             url=crud_article_url,
-            **{
-                "params": {"api_key": "doaj-api-key-1234"},
-                "json": {
-                    "id": "doaj-id",
-                    "field": "value",
-                }
+            params=article_exporter.params_request,
+            json={
+                "id": "doaj-id",
+                "field": "value",
             },
         )
 
@@ -381,14 +366,9 @@ class GetXyloseArticleExporterAdapterTest(
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
     @mock.patch("exporter.main.requests")
-    @mock.patch(
-        "exporter.main.doaj.DOAJExporterXyloseArticle.get_request",
-        new_callable=mock.PropertyMock,
-    )
     def test_get_calls_requests_get_to_doaj_api_with_doaj_get_request(
-        self, mk_get_request, mk_requests
+        self, mk_requests
     ):
-        mk_get_request.return_value = { "params": {"api_key": "doaj-api-key-1234"} }
         article_exporter = XyloseArticleExporterAdapter(
             index=self.index, command=self.index_command, article=self.article
         )
@@ -397,7 +377,7 @@ class GetXyloseArticleExporterAdapterTest(
         article_exporter.command_function()
         mk_requests.get.assert_called_once_with(
             url=crud_article_url,
-            **{ "params": { "api_key": "doaj-api-key-1234" } },
+            params=article_exporter.params_request,
         )
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
@@ -454,14 +434,9 @@ class DeleteXyloseArticleExporterAdapterTest(
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
     @mock.patch("exporter.main.requests")
-    @mock.patch(
-        "exporter.main.doaj.DOAJExporterXyloseArticle.delete_request",
-        new_callable=mock.PropertyMock,
-    )
     def test_delete_calls_requests_delete_to_doaj_api_with_doaj_delete_request(
-        self, mk_delete_request, mk_requests
+        self, mk_requests
     ):
-        mk_delete_request.return_value = { "params": {"api_key": "doaj-api-key-1234"} }
         article_exporter = XyloseArticleExporterAdapter(
             index=self.index, command=self.index_command, article=self.article
         )
@@ -470,7 +445,7 @@ class DeleteXyloseArticleExporterAdapterTest(
         article_exporter.command_function()
         mk_requests.delete.assert_called_once_with(
             url=crud_article_url,
-            **{ "params": { "api_key": "doaj-api-key-1234" } },
+            params=article_exporter.params_request,
         )
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -131,6 +131,7 @@ class XyloseArticleExporterAdapterTestMixin:
             )
         self.assertEqual(str(exc.exception), "Comando informado inválido: abc")
 
+
 class ExportXyloseArticleExporterAdapterTest(
     XyloseArticleExporterAdapterTestMixin, TestCase,
 ):
@@ -979,10 +980,7 @@ class ArticleMetaParserTest(TestCase):
 
 
 class MainExporterTestMixin:
-    @mock.patch("exporter.main.process_extracted_documents")
-    def test_raises_exception_if_no_index_command(
-        self, mk_process_extracted_documents
-    ):
+    def test_raises_exception_if_no_index_command(self):
         with self.assertRaises(SystemExit) as exc:
             main_exporter(
                 [
@@ -991,10 +989,7 @@ class MainExporterTestMixin:
                 ]
             )
 
-    @mock.patch("exporter.main.process_extracted_documents")
-    def test_raises_exception_if_no_doaj_command(
-        self, mk_process_extracted_documents
-    ):
+    def test_raises_exception_if_no_doaj_command(self):
         with self.assertRaises(SystemExit) as exc:
             main_exporter(
                 [
@@ -1004,10 +999,7 @@ class MainExporterTestMixin:
                 ]
             )
 
-    @mock.patch("exporter.main.process_extracted_documents")
-    def test_raises_exception_if_no_dates_nor_pids(
-        self, mk_process_extracted_documents
-    ):
+    def test_raises_exception_if_no_dates_nor_pids(self):
         with self.assertRaises(OriginDataFilterError) as exc:
             main_exporter(
                 [
@@ -1022,10 +1014,7 @@ class MainExporterTestMixin:
             "Informe ao menos uma das datas (from-date ou until-date), pid ou pids",
         )
 
-    @mock.patch("exporter.main.process_extracted_documents")
-    def test_raises_exception_if_pid_and_no_collection(
-        self, mk_process_extracted_documents
-    ):
+    def test_raises_exception_if_pid_and_no_collection(self):
         with self.assertRaises(OriginDataFilterError) as exc:
             main_exporter(
                 [
@@ -1042,10 +1031,7 @@ class MainExporterTestMixin:
             "Coleção é obrigatória para exportação de um PID",
         )
 
-    @mock.patch("exporter.main.process_extracted_documents")
-    def test_raises_exception_if_pids_and_no_collection(
-        self, mk_process_extracted_documents
-    ):
+    def test_raises_exception_if_pids_and_no_collection(self):
         pids = [
             "S0100-19651998000200001",
             "S0100-19651998000200002",
@@ -1071,8 +1057,7 @@ class MainExporterTestMixin:
             )
 
     @mock.patch("exporter.main.AMClient")
-    @mock.patch("exporter.main.process_extracted_documents")
-    def test_instanciates_AMClient(self, mk_process_extracted_documents, MockAMClient):
+    def test_instanciates_AMClient(self, MockAMClient):
         main_exporter(
             [
                 "--output",
@@ -1090,10 +1075,7 @@ class MainExporterTestMixin:
         MockAMClient.assert_called_with(connection="thrift")
 
     @mock.patch("exporter.main.AMClient")
-    @mock.patch("exporter.main.process_extracted_documents")
-    def test_instanciates_AMClient_with_another_domain(
-        self, mk_process_extracted_documents, MockAMClient
-    ):
+    def test_instanciates_AMClient_with_another_domain(self, MockAMClient):
         main_exporter(
             [
                 "--output",
@@ -1111,9 +1093,8 @@ class MainExporterTestMixin:
         MockAMClient.assert_called_with(domain="http://anotheram.scielo.org")
 
     @mock.patch.object(AMClient, "document")
-    @mock.patch("exporter.main.process_extracted_documents")
     def test_process_extracted_documents_called_with_collection_and_pid(
-        self, mk_process_extracted_documents, mk_document
+        self, mk_document
     ):
         main_exporter(
             [
@@ -1127,7 +1108,7 @@ class MainExporterTestMixin:
                 "S0100-19651998000200002",
             ]
         )
-        mk_process_extracted_documents.assert_called_with(
+        self.mk_process_documents.assert_called_with(
             get_document=mk_document,
             index=self.index,
             index_command=self.index_command,
@@ -1136,9 +1117,8 @@ class MainExporterTestMixin:
         )
 
     @mock.patch.object(AMClient, "document")
-    @mock.patch("exporter.main.process_extracted_documents")
     def test_process_extracted_documents_called_with_collection_and_pids_from_file(
-        self, mk_process_extracted_documents, mk_document
+        self, mk_document
     ):
         pids = [
             "S0100-19651998000200001",
@@ -1160,7 +1140,7 @@ class MainExporterTestMixin:
                     str(pids_file),
                 ]
             )
-        mk_process_extracted_documents.assert_called_with(
+        self.mk_process_documents.assert_called_with(
             get_document=mk_document,
             index=self.index,
             index_command=self.index_command,
@@ -1170,10 +1150,8 @@ class MainExporterTestMixin:
 
     @mock.patch("exporter.main.utils.get_valid_datetime")
     @mock.patch.object(AMClient, "documents_identifiers")
-    @mock.patch("exporter.main.process_extracted_documents")
     def test_calls_get_valid_datetime_with_dates(
         self,
-        mk_process_extracted_documents,
         mk_documents_identifiers,
         mk_get_valid_datetime,
     ):
@@ -1204,9 +1182,8 @@ class MainExporterTestMixin:
         )
 
     @mock.patch.object(AMClient, "documents_identifiers")
-    @mock.patch("exporter.main.process_extracted_documents")
     def test_calls_am_client_documents_identifiers_with_args(
-        self, mk_process_extracted_documents, mk_documents_identifiers
+        self, mk_documents_identifiers
     ):
         tests_args_and_calls = [
             (["--from-date", "01-01-2021",], {"from_date": datetime(2021, 1, 1, 0, 0)}),
@@ -1243,9 +1220,8 @@ class MainExporterTestMixin:
 
     @mock.patch.object(AMClient, "documents_identifiers")
     @mock.patch.object(AMClient, "document")
-    @mock.patch("exporter.main.process_extracted_documents")
     def test_process_extracted_documents_called_with_identifiers_from_date_search(
-        self, mk_process_extracted_documents, mk_document, mk_documents_identifiers
+        self, mk_document, mk_documents_identifiers
     ):
         mk_documents_identifiers.return_value = [
             {
@@ -1279,7 +1255,7 @@ class MainExporterTestMixin:
                 "07-01-2021",
             ],
         )
-        mk_process_extracted_documents.assert_called_once_with(
+        self.mk_process_documents.assert_called_once_with(
             get_document=mk_document,
             index=self.index,
             index_command=self.index_command,
@@ -1297,11 +1273,25 @@ class DOAJExportMainExporterTest(MainExporterTestMixin, TestCase):
     index_command = "export"
     output_path = pathlib.Path("output.log")
 
+    def setUp(self):
+        self.patcher = mock.patch("exporter.main.process_extracted_documents")
+        self.mk_process_documents = self.patcher.start()
+
+    def tearDown(self):
+        self.mk_process_documents.stop()
+
 
 class DOAJUpdateMainExporterTest(MainExporterTestMixin, TestCase):
     index = "doaj"
     index_command = "update"
     output_path = pathlib.Path("output.log")
+
+    def setUp(self):
+        self.patcher = mock.patch("exporter.main.process_extracted_documents")
+        self.mk_process_documents = self.patcher.start()
+
+    def tearDown(self):
+        self.mk_process_documents.stop()
 
 
 class DOAJGetMainExporterTest(MainExporterTestMixin, TestCase):
@@ -1310,12 +1300,22 @@ class DOAJGetMainExporterTest(MainExporterTestMixin, TestCase):
 
     def setUp(self):
         self.output_path = pathlib.Path(tempfile.mkdtemp())
+        self.patcher = mock.patch("exporter.main.process_extracted_documents")
+        self.mk_process_documents = self.patcher.start()
 
     def tearDown(self):
         shutil.rmtree(self.output_path)
+        self.mk_process_documents.stop()
 
 
 class DOAJDeleteMainExporterTest(MainExporterTestMixin, TestCase):
     index = "doaj"
     index_command = "delete"
     output_path = pathlib.Path("output.log")
+
+    def setUp(self):
+        self.patcher = mock.patch("exporter.main.process_extracted_documents")
+        self.mk_process_documents = self.patcher.start()
+
+    def tearDown(self):
+        self.mk_process_documents.stop()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -466,7 +466,7 @@ class ProcessExtractedDocumentsTestMixin:
             get_document=self.mk_get_document,
             index=self.index,
             index_command=self.index_command,
-            output_path=pathlib.Path("output.log"),
+            output_path=self.output_path,
             pids_by_collection={"scl": ["S0100-19651998000200002"]},
         )
         mk_process_document.assert_called_with(
@@ -487,7 +487,7 @@ class ProcessExtractedDocumentsTestMixin:
             get_document=self.mk_get_document,
             index=self.index,
             index_command=self.index_command,
-            output_path=pathlib.Path("output.log"),
+            output_path=self.output_path,
             pids_by_collection={"scl": pids},
         )
         for pid in pids:
@@ -510,7 +510,7 @@ class ProcessExtractedDocumentsTestMixin:
                 get_document=self.mk_get_document,
                 index=self.index,
                 index_command=self.index_command,
-                output_path=pathlib.Path("output.log"),
+                output_path=self.output_path,
                 pids_by_collection={"scl": ["S0100-19651998000200001"]},
             )
             mk_logger_error.assert_called_once_with(
@@ -519,7 +519,19 @@ class ProcessExtractedDocumentsTestMixin:
                 exc
             )
 
-    def test_all_docs_successfully_posted_are_recorded_to_file(
+
+class ExportExtractedDocumentsTest(ProcessExtractedDocumentsTestMixin, TestCase):
+    index = "doaj"
+    index_command = "export"
+    output_path = pathlib.Path("output.log")
+
+    @vcr.use_cassette("tests/fixtures/vcr_cassettes/S0100-19651998000200002.yml")
+    def setUp(self):
+        self.mk_get_document = mock.MagicMock()
+
+    @mock.patch("exporter.main.PoisonPill")
+    @mock.patch("exporter.main.process_document")
+    def test_all_docs_successfully_exported_are_recorded_to_file(
         self, mk_process_document, MockPoisonPill
     ):
         fake_pids = [f"S0100-1965199800020000{count}" for count in range(1, 5)]
@@ -547,16 +559,45 @@ class ProcessExtractedDocumentsTestMixin:
                     self.assertIn(pid, file_content)
 
 
-class ExportExtractedDocumentsTest(ProcessExtractedDocumentsTestMixin, TestCase):
+class UpdateExtractedDocumentsTest(ProcessExtractedDocumentsTestMixin, TestCase):
     index = "doaj"
-    index_command = "export"
+    index_command = "update"
+    output_path = pathlib.Path("output.log")
 
     @vcr.use_cassette("tests/fixtures/vcr_cassettes/S0100-19651998000200002.yml")
     def setUp(self):
         self.mk_get_document = mock.MagicMock()
 
+    @mock.patch("exporter.main.PoisonPill")
+    @mock.patch("exporter.main.process_document")
+    def test_all_docs_successfully_updated_are_recorded_to_file(
+        self, mk_process_document, MockPoisonPill
+    ):
+        fake_pids = [f"S0100-1965199800020000{count}" for count in range(1, 5)]
+        fake_exported_docs = [
+            {
+                "index_id": f"doaj-{pid}",
+                "status": "OK",
+                "pid": pid,
+            }
+            for pid in fake_pids
+        ]
+        mk_process_document.side_effect = fake_exported_docs
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            output_file = pathlib.Path(tmpdirname) / "output.log"
+            process_extracted_documents(
+                get_document=self.mk_get_document,
+                index=self.index,
+                index_command=self.index_command,
+                output_path=output_file,
+                pids_by_collection={"scl": fake_pids},
+            )
+            file_content = output_file.read_text()
+            for pid in fake_pids:
+                with self.subTest(pid=pid):
+                    self.assertIn(pid, file_content)
 
-class UpdateExtractedDocumentsTest(ProcessExtractedDocumentsTestMixin, TestCase):
+
     index = "doaj"
     index_command = "update"
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -252,10 +252,6 @@ class UpdateXyloseArticleExporterAdapterTest(
             "HTTP Error"
         )
         mk_requests.get.return_value = mock_resp
-        mk_requests.get.return_value.json.return_value = {
-            "id": "doaj-id",
-            "error": "wrong field.",
-        }
 
         article_exporter = XyloseArticleExporterAdapter(
             index=self.index, command=self.index_command, article=self.article
@@ -263,7 +259,7 @@ class UpdateXyloseArticleExporterAdapterTest(
         with self.assertRaises(IndexExporterHTTPError) as exc:
             article_exporter.command_function()
         self.assertEqual(
-            "Erro na consulta ao doaj: HTTP Error. wrong field.", str(exc.exception)
+            "Erro na consulta ao doaj: HTTP Error.", str(exc.exception)
         )
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
@@ -411,10 +407,6 @@ class GetXyloseArticleExporterAdapterTest(
             "HTTP Error"
         )
         mk_requests.get.return_value = mock_resp
-        mk_requests.get.return_value.json.return_value = {
-            "id": "doaj-id",
-            "error": "wrong field.",
-        }
 
         article_exporter = XyloseArticleExporterAdapter(
             index=self.index, command=self.index_command, article=self.article
@@ -422,7 +414,7 @@ class GetXyloseArticleExporterAdapterTest(
         with self.assertRaises(IndexExporterHTTPError) as exc:
             article_exporter.command_function()
         self.assertEqual(
-            "Erro na consulta ao doaj: HTTP Error. wrong field.", str(exc.exception)
+            "Erro na consulta ao doaj: HTTP Error.", str(exc.exception)
         )
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -52,6 +52,64 @@ class AMClientTest(TestCase):
         self.assertEqual(document.collection_acronym, "scl")
         self.assertEqual(document.data["article"]["code"], "S0100-19651998000200002")
 
+    @mock.patch("exporter.main.articlemeta_client.RestfulClient.documents_by_identifiers")
+    def test_get_documents_identifiers_calls_documents_by_identifiers(
+        self, mk_documents_by_identifiers
+    ):
+        self.client = self.make_client()
+        documents = self.client.documents_identifiers(
+            collection="scl", from_date=datetime(2021, 8, 2), until_date=datetime(2021, 8, 2)
+        )
+        mk_documents_by_identifiers.assert_called_once_with(
+            collection="scl",
+            from_date="2021-08-02",
+            until_date="2021-08-02",
+            only_identifiers=True,
+        )
+
+    @mock.patch("exporter.main.articlemeta_client.RestfulClient.documents_by_identifiers")
+    def test_get_documents_identifiers_calls_documents_by_identifiers_with_collection(
+        self, mk_documents_by_identifiers
+    ):
+        self.client = self.make_client()
+        documents = self.client.documents_identifiers(collection="scl")
+        mk_documents_by_identifiers.assert_called_once_with(
+            collection="scl", only_identifiers=True,
+        )
+
+    @mock.patch("exporter.main.articlemeta_client.RestfulClient.documents_by_identifiers")
+    def test_get_documents_identifiers_calls_documents_by_identifiers_with_from_date(
+        self, mk_documents_by_identifiers
+    ):
+        self.client = self.make_client()
+        documents = self.client.documents_identifiers(from_date=datetime(2021, 8, 2))
+        mk_documents_by_identifiers.assert_called_once_with(
+            from_date="2021-08-02", only_identifiers=True,
+        )
+
+    @mock.patch("exporter.main.articlemeta_client.RestfulClient.documents_by_identifiers")
+    def test_get_documents_identifiers_calls_documents_by_identifiers_with_until_date(
+        self, mk_documents_by_identifiers
+    ):
+        self.client = self.make_client()
+        documents = self.client.documents_identifiers(until_date=datetime(2021, 8, 2))
+        mk_documents_by_identifiers.assert_called_once_with(
+            until_date="2021-08-02", only_identifiers=True,
+        )
+
+    @vcr.use_cassette(
+        "tests/fixtures/vcr_cassettes/documents-identifiers.yml",
+        record_mode="new_episodes",
+    )
+    def test_get_documents_identifiers_from_collection_from_and_until_dates(self):
+        self.client = self.make_client()
+        documents = self.client.documents_identifiers(
+            collection="scl", from_date=datetime(2021, 8, 2), until_date=datetime(2021, 8, 2)
+        )
+        self.assertIsNotNone(documents)
+        docs = [document["collection"] for document in documents]
+        self.assertEqual(docs[0], "scl")
+
 
 class XyloseArticleExporterAdapterTest(TestCase):
     @vcr.use_cassette("tests/fixtures/vcr_cassettes/S0100-19651998000200002.yml")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -220,6 +220,50 @@ class UpdateXyloseArticleExporterAdapterTest(
     def setUp(self):
         client = AMClient()
         self.article = client.document(collection="scl", pid="S0100-19651998000200002")
+        self.article.data["doaj_id"] = "doaj-id-123456"
+
+    @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
+    @mock.patch("exporter.main.requests")
+    @mock.patch(
+        "exporter.main.doaj.DOAJExporterXyloseArticle.get_request",
+        new_callable=mock.PropertyMock,
+    )
+    def test_update_calls_requests_get_to_doaj_api_with_doaj_get_request(
+        self, mk_get_request, mk_requests
+    ):
+        mk_get_request.return_value = { "params": {"api_key": "doaj-api-key-1234"} }
+        article_exporter = XyloseArticleExporterAdapter(
+            index=self.index, command=self.index_command, article=self.article
+        )
+        crud_article_url = article_exporter.index_exporter.crud_article_url
+
+        article_exporter.command_function()
+        mk_requests.get.assert_called_once_with(
+            url=crud_article_url,
+            **{ "params": { "api_key": "doaj-api-key-1234" } },
+        )
+
+    @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
+    @mock.patch("exporter.main.requests")
+    def test_update_raises_exception_if_get_raises_http_error(self, mk_requests):
+        mock_resp = mock.Mock()
+        mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "HTTP Error"
+        )
+        mk_requests.get.return_value = mock_resp
+        mk_requests.get.return_value.json.return_value = {
+            "id": "doaj-id",
+            "error": "wrong field.",
+        }
+
+        article_exporter = XyloseArticleExporterAdapter(
+            index=self.index, command=self.index_command, article=self.article
+        )
+        with self.assertRaises(IndexExporterHTTPError) as exc:
+            article_exporter.command_function()
+        self.assertEqual(
+            "Erro na consulta ao doaj: HTTP Error. wrong field.", str(exc.exception)
+        )
 
 
 class ProcessDocumentTestMixin:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1024,7 +1024,7 @@ class MainExporterTestMixin:
                     self.index_command,
                     "--pid",
                     "S0100-19651998000200002",
-                ]
+                ] + self.extra_args
             )
         self.assertEqual(
             str(exc.exception),
@@ -1049,7 +1049,7 @@ class MainExporterTestMixin:
                         self.index_command,
                         "--pids",
                         str(pids_file),
-                    ]
+                    ] + self.extra_args
                 )
             self.assertEqual(
                 str(exc.exception),
@@ -1070,7 +1070,7 @@ class MainExporterTestMixin:
                 "spa",
                 "--pid",
                 "S0100-19651998000200002",
-            ]
+            ] + self.extra_args
         )
         MockAMClient.assert_called_with(connection="thrift")
 
@@ -1088,7 +1088,7 @@ class MainExporterTestMixin:
                 "spa",
                 "--pid",
                 "S0100-19651998000200002",
-            ]
+            ] + self.extra_args
         )
         MockAMClient.assert_called_with(domain="http://anotheram.scielo.org")
 
@@ -1106,7 +1106,7 @@ class MainExporterTestMixin:
                 "spa",
                 "--pid",
                 "S0100-19651998000200002",
-            ]
+            ] + self.extra_args
         )
         self.mk_process_documents.assert_called_with(
             get_document=mk_document,
@@ -1138,7 +1138,7 @@ class MainExporterTestMixin:
                     "spa",
                     "--pids",
                     str(pids_file),
-                ]
+                ] + self.extra_args
             )
         self.mk_process_documents.assert_called_with(
             get_document=mk_document,
@@ -1169,7 +1169,7 @@ class MainExporterTestMixin:
                     self.index,
                     self.index_command,
                 ] +
-                args
+                args + self.extra_args
             )
 
         mk_get_valid_datetime.assert_has_calls(
@@ -1214,7 +1214,7 @@ class MainExporterTestMixin:
                         self.index,
                         self.index_command,
                     ] +
-                    args
+                    args + self.extra_args
                 )
                 mk_documents_identifiers.assert_called_with(**call_params)
 
@@ -1253,7 +1253,7 @@ class MainExporterTestMixin:
                 "01-01-2021",
                 "--until-date",
                 "07-01-2021",
-            ],
+            ] + self.extra_args
         )
         self.mk_process_documents.assert_called_once_with(
             get_document=mk_document,
@@ -1272,9 +1272,24 @@ class DOAJExportMainExporterTest(MainExporterTestMixin, TestCase):
     index = "doaj"
     index_command = "export"
     output_path = pathlib.Path("output.log")
+    extra_args = []
 
     def setUp(self):
         self.patcher = mock.patch("exporter.main.process_extracted_documents")
+        self.mk_process_documents = self.patcher.start()
+
+    def tearDown(self):
+        self.mk_process_documents.stop()
+
+
+class DOAJExportinBulkMainExporterTest(MainExporterTestMixin, TestCase):
+    index = "doaj"
+    index_command = "export"
+    output_path = pathlib.Path("output.log")
+    extra_args = ["--bulk"]
+
+    def setUp(self):
+        self.patcher = mock.patch("exporter.main.process_documents_in_bulk")
         self.mk_process_documents = self.patcher.start()
 
     def tearDown(self):
@@ -1285,6 +1300,7 @@ class DOAJUpdateMainExporterTest(MainExporterTestMixin, TestCase):
     index = "doaj"
     index_command = "update"
     output_path = pathlib.Path("output.log")
+    extra_args = []
 
     def setUp(self):
         self.patcher = mock.patch("exporter.main.process_extracted_documents")
@@ -1297,6 +1313,7 @@ class DOAJUpdateMainExporterTest(MainExporterTestMixin, TestCase):
 class DOAJGetMainExporterTest(MainExporterTestMixin, TestCase):
     index = "doaj"
     index_command = "get"
+    extra_args = []
 
     def setUp(self):
         self.output_path = pathlib.Path(tempfile.mkdtemp())
@@ -1312,6 +1329,7 @@ class DOAJDeleteMainExporterTest(MainExporterTestMixin, TestCase):
     index = "doaj"
     index_command = "delete"
     output_path = pathlib.Path("output.log")
+    extra_args = []
 
     def setUp(self):
         self.patcher = mock.patch("exporter.main.process_extracted_documents")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1195,3 +1195,9 @@ class DOAJGetMainExporterTest(MainExporterTestMixin, TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.output_path)
+
+
+class DOAJDeleteMainExporterTest(MainExporterTestMixin, TestCase):
+    index = "doaj"
+    index_command = "delete"
+    output_path = pathlib.Path("output.log")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,7 @@ from exporter.main import (
     ArticleMetaDocumentNotFound,
     InvalidIndexExporter,
     IndexExporterHTTPError,
+    OriginDataFilterError,
     XyloseArticleExporterAdapter,
     export_document,
     articlemeta_parser,
@@ -514,7 +515,22 @@ class ArticleMetaParserTest(TestCase):
 class MainExporterTest(TestCase):
     @mock.patch("exporter.main.extract_and_export_documents")
     def test_extract_and_export_documents_called_with_collection_and_pid(
+    def test_raises_exception_if_no_dates_nor_pids(
         self, mk_extract_and_export_documents
+    ):
+        with self.assertRaises(OriginDataFilterError) as exc:
+            main_exporter(
+                [
+                    "--output",
+                    "output.log",
+                    "doaj",
+                ]
+            )
+        self.assertEqual(
+            str(exc.exception),
+            "Informe ao menos uma das datas (from-date ou until-date), pid ou pids",
+        )
+
     ):
         main_exporter(
             [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -494,24 +494,26 @@ class ProcessDocumentTestMixin:
         )
 
     @mock.patch("exporter.main.XyloseArticleExporterAdapter", autospec=True)
-    def test_calls_XyloseArticleExporterAdapter_command_function(
+    def test_returns_XyloseArticleExporterAdapter_command_function(
         self, MockXyloseArticleExporterAdapter
     ):
         document = mock.create_autospec(
             spec=scielodocument.Article, data={"id": "document-1234"}
         )
         mk_document = mock.Mock(return_value=document)
-        mk_command_function = mock.Mock(return_value={})
+        mk_command_function = mock.Mock(
+            return_value={"id": "doaj-id-1234", "status": "OK"}
+        )
         MockXyloseArticleExporterAdapter.return_value.command_function = \
             mk_command_function
-        process_document(
+        ret = process_document(
             mk_document,
             index=self.index,
             index_command=self.index_command,
             collection="scl",
             pid="S0100-19651998000200002",
         )
-        mk_command_function.assert_called_once()
+        self.assertEqual(ret, {"id": "doaj-id-1234", "status": "OK"})
 
 
 class ExportDocumentTest(ProcessDocumentTestMixin, TestCase):
@@ -651,7 +653,7 @@ class UpdateExtractedDocumentsTest(ProcessExtractedDocumentsTestMixin, TestCase)
         fake_exported_docs = [
             {
                 "index_id": f"doaj-{pid}",
-                "status": "OK",
+                "status": "UPDATED",
                 "pid": pid,
             }
             for pid in fake_pids

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1641,3 +1641,17 @@ class DOAJDeleteMainExporterTest(MainExporterTestMixin, TestCase):
 
     def tearDown(self):
         self.mk_process_documents.stop()
+
+
+class DOAJDeleteinBulkMainExporterTest(MainExporterTestMixin, TestCase):
+    index = "doaj"
+    index_command = "delete"
+    output_path = pathlib.Path("output.log")
+    extra_args = ["--bulk"]
+
+    def setUp(self):
+        self.patcher = mock.patch("exporter.main.process_documents_in_bulk")
+        self.mk_process_documents = self.patcher.start()
+
+    def tearDown(self):
+        self.mk_process_documents.stop()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -171,8 +171,10 @@ class ExportXyloseArticleExporterAdapterTest(
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
     @mock.patch("exporter.main.requests")
-    def test_export_raises_exception_if_post_raises_http_error(self, mk_requests):
-        mock_resp = mock.Mock()
+    def test_export_raises_exception_with_json_error_if_post_raises_400_http_error(
+        self, mk_requests
+    ):
+        mock_resp = mock.Mock(status_code=400)
         mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
             "HTTP Error"
         )
@@ -189,6 +191,24 @@ class ExportXyloseArticleExporterAdapterTest(
             article_exporter.command_function()
         self.assertEqual(
             "Erro na exportação ao doaj: HTTP Error. wrong field.", str(exc.exception)
+        )
+
+    @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
+    @mock.patch("exporter.main.requests")
+    def test_export_raises_exception_if_post_raises_http_error(self, mk_requests):
+        mock_resp = mock.Mock()
+        mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "HTTP Error"
+        )
+        mk_requests.post.return_value = mock_resp
+
+        article_exporter: doaj.DOAJExporterXyloseArticle = XyloseArticleExporterAdapter(
+            index=self.index, command=self.index_command, article=self.article
+        )
+        with self.assertRaises(IndexExporterHTTPError) as exc:
+            article_exporter.command_function()
+        self.assertEqual(
+            "Erro na exportação ao doaj: HTTP Error.", str(exc.exception)
         )
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
@@ -314,10 +334,10 @@ class UpdateXyloseArticleExporterAdapterTest(
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
     @mock.patch("exporter.main.requests")
     @mock.patch("exporter.main.doaj.DOAJExporterXyloseArticle.put_request")
-    def test_update_raises_exception_if_put_raises_http_error(
+    def test_update_raises_exception_with_json_error_if_put_raises_400_http_error(
         self, mk_put_request, mk_requests,
     ):
-        mock_put_resp = mock.Mock()
+        mock_put_resp = mock.Mock(status_code=400)
         mock_put_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
             "HTTP Error"
         )
@@ -334,6 +354,27 @@ class UpdateXyloseArticleExporterAdapterTest(
             article_exporter.command_function()
         self.assertEqual(
             "Erro ao atualizar o doaj: HTTP Error. wrong field.", str(exc.exception)
+        )
+
+    @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
+    @mock.patch("exporter.main.requests")
+    @mock.patch("exporter.main.doaj.DOAJExporterXyloseArticle.put_request")
+    def test_update_raises_exception_if_put_raises_http_error(
+        self, mk_put_request, mk_requests,
+    ):
+        mock_put_resp = mock.Mock()
+        mock_put_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "HTTP Error"
+        )
+        mk_requests.put.return_value = mock_put_resp
+
+        article_exporter = XyloseArticleExporterAdapter(
+            index=self.index, command=self.index_command, article=self.article
+        )
+        with self.assertRaises(IndexExporterHTTPError) as exc:
+            article_exporter.command_function()
+        self.assertEqual(
+            "Erro ao atualizar o doaj: HTTP Error.", str(exc.exception)
         )
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
@@ -553,8 +594,10 @@ class PostXyloseArticlesListExporterAdapterTest(
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
     @mock.patch("exporter.main.requests")
-    def test_export_raises_exception_if_post_raises_http_error(self, mk_requests):
-        mock_resp = mock.Mock()
+    def test_export_raises_exception_with_json_error_if_post_raises_400_http_error(
+        self, mk_requests
+    ):
+        mock_resp = mock.Mock(status_code=400)
         mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
             "HTTP Error"
         )
@@ -571,6 +614,24 @@ class PostXyloseArticlesListExporterAdapterTest(
             articles_exporter.command_function()
         self.assertEqual(
             "Erro na exportação ao doaj: HTTP Error. wrong field.", str(exc.exception)
+        )
+
+    @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})
+    @mock.patch("exporter.main.requests")
+    def test_export_raises_exception_if_post_raises_http_error(self, mk_requests):
+        mock_resp = mock.Mock()
+        mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "HTTP Error"
+        )
+        mk_requests.post.return_value = mock_resp
+
+        articles_exporter = XyloseArticlesListExporterAdapter(
+            index=self.index, command=self.index_command, articles=set(self.articles)
+        )
+        with self.assertRaises(IndexExporterHTTPError) as exc:
+            articles_exporter.command_function()
+        self.assertEqual(
+            "Erro na exportação ao doaj: HTTP Error.", str(exc.exception)
         )
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -151,16 +151,19 @@ class ExportXyloseArticleExporterAdapterTest(
             new_callable=mock.PropertyMock,
         ) as mk_post_request:
             mk_post_request.return_value = {
-                "api_key": "doaj-api-key-1234",
+                "params": {"api_key": "doaj-api-key-1234"},
                 "json": {"field": "value"},
             }
-            article_exporter: doaj.DOAJExporterXyloseArticle = XyloseArticleExporterAdapter(
-                index=self.index, command=self.index_command, article=self.article
+            article_exporter = XyloseArticleExporterAdapter(
+                index=self.index, command=self.index_command, article=self.article,
             )
             article_exporter.command_function()
             mk_requests.post.assert_called_once_with(
-                url=article_exporter.index_exporter.crud_article_url,
-                **{"api_key": "doaj-api-key-1234", "json": {"field": "value"}},
+                url=article_exporter.index_exporter.crud_article_put_url,
+                **{
+                    "params": {"api_key": "doaj-api-key-1234"},
+                    "json": {"field": "value"},
+                },
             )
 
     @mock.patch.dict("os.environ", {"DOAJ_API_KEY": "doaj-api-key-1234"})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+from unittest import TestCase
+
+from exporter import utils
+
+
+class GetValidDatetimeTest(TestCase):
+    def test_raises_exception_if_invalid_date(self):
+        dates = ["01-01-01", "01-01", "01/01", "01/01/01", "2021-01-01"]
+        for date in dates:
+            with self.subTest(date=date):
+                with self.assertRaises(ValueError) as exc_info:
+                    utils.get_valid_datetime(date)
+                self.assertEqual(
+                    str(exc_info.exception),
+                    "Data inválida. Formato esperado: DD-MM-YYYY",
+                )
+
+    def test_returns_datetime(self):
+        date = utils.get_valid_datetime("01-01-2021")
+        self.assertEqual(date, datetime(2021, 1, 1))


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona funcionalidade de deleção de artigos em lote implementando método `HTTP DELETE /bulk/articles` do DOAJ. Em caso de sucesso, o resultado será salvo no argumento `--output`.

#### Onde a revisão poderia começar?
Commit 65163ec.

#### Como este poderia ser testado manualmente?
1. Instale localmente o exportador: `pip install --editable .`
2. Configure variável de ambiente `DOAJ_API_KEY`com a API KEY do DOAJ
3. Executar o exportador com o PID de um documento: `scielo-export --output <caminho para arquivo de saída> doaj delete --collection <acrônimo da coleção> --pid <PID de artigo> --bulk`
4. A aplicação não deve ser interrompida por qualquer exceção HTTP
5. Em caso de sucesso, o resultado deverá estar salvo no arquivo ou diretório cujo caminho foi passado no parâmetro `--output`.

#### Algum cenário de contexto que queira dar?
Conforme relatado em PR anterior, nem todos os artigos da fonte tem o ID do DOAJ e, nestes casos, não será possível efetuar a deleção.

### Screenshots
N/A.

#### Quais são tickets relevantes?
.

### Referências
.
