### PR TITLE
Adiciona gerenciamento de ISSNs cujos documentos serão enviados ao DOAJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
 # scielo_exports_doaj
+
+__scielo-export__
+```bash
+usage: scielo-export [-h] [--loglevel LOGLEVEL] [--issns ISSNS] --output OUTPUT {doaj} ...
+
+Exportador de documentos
+
+optional arguments:
+  -h, --help           show this help message and exit
+  --loglevel LOGLEVEL
+  --issns ISSNS        Caminho para arquivo de ISSNs gerenciados
+  --output OUTPUT      Caminho para arquivo de resultado da exportação
+
+Index:
+  {doaj}
+    doaj               Base de indexação DOAJ
+```
+
+__scielo-export doaj__
+```bash
+usage: scielo-export doaj [-h] {export,update,get,delete} ...
+
+optional arguments:
+  -h, --help            show this help message and exit
+
+DOAJ Command:
+  {export,update,get,delete}
+    export              Exporta documentos
+    update              Atualiza documentos
+    get                 Obtém documentos
+    delete              Deleta documentos
+```
+
+__scielo-export doaj export__
+```bash
+usage: scielo-export doaj export [-h] [--from-date FROM_DATE] [--until-date UNTIL_DATE] [--collection COLLECTION] [--pid PID] [--pids PIDS] [--connection CONNECTION] [--domain DOMAIN] [--bulk]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --from-date FROM_DATE
+                        Data inicial de processamento
+  --until-date UNTIL_DATE
+                        Data final de processamento
+  --collection COLLECTION
+                        Coleção do(s) documento(s) publicados
+  --pid PID             PID do documento
+  --pids PIDS           Caminho para arquivo com lista de PIDs de documentos a exportar
+  --connection CONNECTION
+                        Tipo de conexão com Article Meta: Restful ou Thrift
+  --domain DOMAIN       Endereço de conexão com Article Meta
+  --bulk                Exporta documentos em lote
+```

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -581,6 +581,12 @@ def main_exporter(sargs):
     parser = argparse.ArgumentParser(description="Exportador de documentos")
     parser.add_argument("--loglevel", default="INFO")
     parser.add_argument(
+        "--issns", 
+        type=pathlib.Path,
+        default=set(),
+        help="Caminho para arquivo de ISSNs gerenciados",
+    )
+    parser.add_argument(
         "--output",
         type=pathlib.Path,
         required=True,

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -556,7 +556,7 @@ def articlemeta_parser(sargs):
         type=str,
         action=FutureDateAction,
         dest="from_date",
-        help="Data inicial de processamento",
+        help="Data inicial de processamento (dd/mm/yyyy)",
     )
 
     parser.add_argument(
@@ -564,7 +564,7 @@ def articlemeta_parser(sargs):
         type=str,
         dest="until_date",
         action=FutureDateAction,
-        help="Data final de processamento",
+        help="Data final de processamento (dd/mm/yyyy)",
     )
 
     parser.add_argument(

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -35,6 +35,10 @@ class OriginDataFilterError(Exception):
     pass
 
 
+class UnmanagedJournalDocument(Exception):
+    pass
+
+
 class AMClient:
     def __init__(self, connection: str = None, domain: str = None):
         self._client = self._get_client(connection, domain)

--- a/exporter/utils.py
+++ b/exporter/utils.py
@@ -33,3 +33,17 @@ def extract_issns_from_file(issns: Path):
     except:
         raise ISSNFileError()
 
+
+def extract_issns_from_document(document: scielodocument.Article):
+    try:
+        doc_issns = [
+            document.journal.any_issn(), 
+            document.journal.scielo_issn, 
+            document.electronic_issn, 
+            document.print_issn
+        ]
+        return set([i for i in doc_issns if i])
+    except AttributeError:
+        return set()
+
+

--- a/exporter/utils.py
+++ b/exporter/utils.py
@@ -26,3 +26,10 @@ def is_valid_issn(issn: str):
     return False
 
 
+def extract_issns_from_file(issns: Path):
+    try:
+        with open(issns) as fin:
+            return set([i.strip() for i in fin if is_valid_issn(i.strip())])
+    except:
+        raise ISSNFileError()
+

--- a/exporter/utils.py
+++ b/exporter/utils.py
@@ -47,3 +47,7 @@ def extract_issns_from_document(document: scielodocument.Article):
         return set()
 
 
+def is_managed_journal_document(doc_issns: set, managed_issns: set):
+    if doc_issns.intersection(managed_issns):
+        return True
+    return False

--- a/exporter/utils.py
+++ b/exporter/utils.py
@@ -18,3 +18,11 @@ def get_valid_datetime(strdate: str) -> datetime:
         raise ValueError("Data inválida. Formato esperado: DD-MM-YYYY") from None
     else:
         return date
+
+
+def is_valid_issn(issn: str):
+    if len(issn) == 9 and '-' in issn[4]:
+        return True
+    return False
+
+

--- a/exporter/utils.py
+++ b/exporter/utils.py
@@ -1,4 +1,10 @@
 from datetime import datetime
+from pathlib import Path
+from xylose import scielodocument
+
+
+class ISSNFileError(Exception):
+    pass
 
 
 def utcnow():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = scielo_exports_doaj
-version = 1.0.0
+version = 1.1.0
 author = Paty Morimoto
 description = SciELO DOAJ metadata exporter
 long_description = file: README.md

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -759,6 +759,7 @@ class ProcessDocumentTestMixin:
             index_command=self.index_command,
             collection="scl",
             pid="S0100-19651998000200002",
+            managed_issns=set(),
         )
         mk_document.assert_called_with(collection="scl", pid="S0100-19651998000200002")
 
@@ -771,6 +772,7 @@ class ProcessDocumentTestMixin:
                 index_command=self.index_command,
                 collection="scl",
                 pid="S0100-19651998000200002",
+                managed_issns=set(),
             )
         self.assertEqual(str(exc_info.exception), "No document found")
 
@@ -783,6 +785,7 @@ class ProcessDocumentTestMixin:
                 index_command=self.index_command,
                 collection="scl",
                 pid="S0100-19651998000200002",
+                managed_issns=set(),
             )
 
     @mock.patch("exporter.main.XyloseArticleExporterAdapter")
@@ -797,6 +800,7 @@ class ProcessDocumentTestMixin:
             index_command=self.index_command,
             collection="scl",
             pid="S0100-19651998000200002",
+            managed_issns=set(),
         )
         MockXyloseArticleExporterAdapter.assert_called_once_with(
             self.index, self.index_command, document,
@@ -821,6 +825,7 @@ class ProcessDocumentTestMixin:
             index_command=self.index_command,
             collection="scl",
             pid="S0100-19651998000200002",
+            managed_issns=set(),
         )
         self.assertEqual(ret, {"id": "doaj-id-1234", "status": "OK"})
 
@@ -858,6 +863,7 @@ class ProcessExtractedDocumentsTestMixin:
             index_command=self.index_command,
             output_path=self.output_path,
             pids_by_collection={"scl": ["S0100-19651998000200002"]},
+            managed_issns=set(),
         )
         mk_process_document.assert_called_with(
             get_document=self.mk_get_document,
@@ -865,6 +871,7 @@ class ProcessExtractedDocumentsTestMixin:
             index_command=self.index_command,
             collection="scl",
             pid="S0100-19651998000200002",
+            managed_issns=set(),
             poison_pill=MockPoisonPill(),
         )
 
@@ -879,6 +886,7 @@ class ProcessExtractedDocumentsTestMixin:
             index_command=self.index_command,
             output_path=self.output_path,
             pids_by_collection={"scl": pids},
+            managed_issns=set(),
         )
         for pid in pids:
             mk_process_document.assert_any_call(
@@ -887,6 +895,7 @@ class ProcessExtractedDocumentsTestMixin:
                 index_command=self.index_command,
                 collection="scl",
                 pid=pid,
+                managed_issns=set(),
                 poison_pill=MockPoisonPill(),
             )
 
@@ -902,6 +911,7 @@ class ProcessExtractedDocumentsTestMixin:
                 index_command=self.index_command,
                 output_path=self.output_path,
                 pids_by_collection={"scl": ["S0100-19651998000200001"]},
+                managed_issns=set(),
             )
             mk_logger_error.assert_called_once_with(
                 "Não foi possível processar documento '%s': '%s'.",
@@ -942,6 +952,7 @@ class ExportExtractedDocumentsTest(ProcessExtractedDocumentsTestMixin, TestCase)
                 index_command=self.index_command,
                 output_path=output_file,
                 pids_by_collection={"scl": fake_pids},
+                managed_issns=set(),
             )
             file_content = output_file.read_text()
             for pid in fake_pids:
@@ -981,6 +992,7 @@ class UpdateExtractedDocumentsTest(ProcessExtractedDocumentsTestMixin, TestCase)
                 index_command=self.index_command,
                 output_path=output_file,
                 pids_by_collection={"scl": fake_pids},
+                managed_issns=set(),
             )
             file_content = output_file.read_text()
             for pid in fake_pids:
@@ -1021,6 +1033,7 @@ class GetExtractedDocumentsTest(ProcessExtractedDocumentsTestMixin, TestCase):
             index_command=self.index_command,
             output_path=self.output_path,
             pids_by_collection={"scl": fake_pids},
+            managed_issns=set(),
         )
         for pid in fake_pids:
             with self.subTest(pid=pid):
@@ -1069,6 +1082,7 @@ class DeleteExtractedDocumentsTest(ProcessExtractedDocumentsTestMixin, TestCase)
                 index_command=self.index_command,
                 output_path=output_file,
                 pids_by_collection={"scl": fake_pids},
+                managed_issns=set(),
             )
             file_content = output_file.read_text()
             for pid in fake_pids:
@@ -1092,12 +1106,14 @@ class ProcessDocumentsInBulkTestMixin:
             index_command=self.index_command,
             output_path=self.output_path,
             pids_by_collection={"scl": self.pids},
+            managed_issns=set(),
         )
         for pid in self.pids:
             mk_execute_get_document.assert_any_call(
                 get_document=self.mk_get_document,
                 collection="scl",
                 pid=pid,
+                managed_issns=set(),
                 poison_pill=MockPoisonPill(),
             )
 
@@ -1120,6 +1136,7 @@ class ProcessDocumentsInBulkTestMixin:
                 index_command=self.index_command,
                 output_path=self.output_path,
                 pids_by_collection={"scl": self.pids},
+                managed_issns=set(),
             )
             mk_logger_error.assert_called_once_with(
                 "Não foi possível processar documento '%s': '%s'.",
@@ -1145,6 +1162,7 @@ class ProcessDocumentsInBulkTestMixin:
             index_command=self.index_command,
             output_path=self.output_path,
             pids_by_collection={"scl": self.pids},
+            managed_issns=set(),
         )
         MockXyloseArticlesListExporterAdapter.assert_called_once_with(
             self.index, self.index_command, {self.articles[0], self.articles[2]}
@@ -1164,6 +1182,7 @@ class ProcessDocumentsInBulkTestMixin:
             index_command=self.index_command,
             output_path=self.output_path,
             pids_by_collection={"scl": self.pids},
+            managed_issns=set(),
         )
         MockXyloseArticlesListExporterAdapter.assert_not_called()
 
@@ -1183,6 +1202,7 @@ class ProcessDocumentsInBulkTestMixin:
             index_command=self.index_command,
             output_path=self.output_path,
             pids_by_collection={"scl": self.pids},
+            managed_issns=set(),
         )
         mk_command_function.assert_called_once_with()
 
@@ -1205,6 +1225,7 @@ class ProcessDocumentsInBulkTestMixin:
                 index_command=self.index_command,
                 output_path=output_path,
                 pids_by_collection={"scl": self.pids},
+                managed_issns=set(),
             )
             with output_path.open(encoding="utf-8") as fp:
                 self.assertEqual(
@@ -1521,6 +1542,7 @@ class MainExporterTestMixin:
             index_command=self.index_command,
             output_path=self.output_path,
             pids_by_collection={"spa": ["S0100-19651998000200002"]},
+            managed_issns=set(),
         )
 
     @mock.patch.object(AMClient, "document")
@@ -1553,6 +1575,7 @@ class MainExporterTestMixin:
             index_command=self.index_command,
             output_path=self.output_path,
             pids_by_collection={"spa": pids},
+            managed_issns=set(),
         )
 
     @mock.patch("exporter.main.utils.get_valid_datetime")
@@ -1672,6 +1695,7 @@ class MainExporterTestMixin:
                 "arg": ["S0202-01019000090090098"],
                 "cub": ["S0303-01019000090090099"],
             },
+            managed_issns=set(),
         )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,9 @@
+import json
+
 from datetime import datetime
-
-from unittest import TestCase
-
 from exporter import utils
+from unittest import TestCase
+from xylose import scielodocument
 
 
 class GetValidDatetimeTest(TestCase):
@@ -20,3 +21,45 @@ class GetValidDatetimeTest(TestCase):
     def test_returns_datetime(self):
         date = utils.get_valid_datetime("01-01-2021")
         self.assertEqual(date, datetime(2021, 1, 1))
+
+
+class ISSNTest(TestCase):
+    def setUp(self):
+        with open("tests/fixtures/fake-article.json") as fp:
+            article_json = json.load(fp)
+        self.article = scielodocument.Article(article_json)
+        self.managed_issns = utils.extract_issns_from_file("tests/fixtures/issns.txt")
+
+    def test_is_valid_issn_returns_true(self):
+        is_valid = utils.is_valid_issn('0123-4567')
+        self.assertTrue(is_valid)
+
+    def test_is_valid_issn_returns_false(self):
+        is_valid = utils.is_valid_issn('01234567')
+        self.assertFalse(is_valid)
+
+    def test_is_managed_journal_document_returns_true(self):
+        doc_issns = utils.extract_issns_from_document(self.article)
+        is_managed = utils.is_managed_journal_document(doc_issns, self.managed_issns)
+        self.assertTrue(is_managed)
+
+    def test_is_managed_journal_document_returns_false(self):
+        doc_issns = set(['0000-1112'])
+
+        is_managed = utils.is_managed_journal_document(doc_issns, self.managed_issns)
+        self.assertFalse(is_managed)
+
+    def test_extract_issns_from_document_returns_set(self):
+        doc_issns = utils.extract_issns_from_document(self.article)
+        expected_issns = set(['0001-3765', '1678-2690'])
+        self.assertSetEqual(doc_issns, expected_issns)
+
+    def test_extract_issns_from_document_invalid_document_returns_empty_set(self):
+        invalid_document = {}
+        doc_issns = utils.extract_issns_from_document(invalid_document)
+        self.assertSetEqual(doc_issns, set())
+
+    def test_extract_issns_from_file_raises_file_error(self):
+        invalid_path = "tests/fixtures/non_existent_file.txt"
+        with self.assertRaises(utils.ISSNFileError) as exec_info:
+            issns = utils.extract_issns_from_file(invalid_path)


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona a capacidade de controlar quais documentos, de acordo com uma lista de ISSNs, será enviado ao DOAJ.

#### Onde a revisão poderia começar?
Pelo primeiro commit.

#### Como este poderia ser testado manualmente?
1. Instale localmente o exportador: `pip install --editable .`
2. Configure variável de ambiente `DOAJ_API_KEY`com a API KEY do DOAJ
3. Executar o exportador com o PID de um documento: `scielo-export --output <caminho para arquivo de saída> --issns <arquivo de ISSNs gerenciados> doaj export --collection <acrônimo da coleção> --pid <PID de artigo>`
4. A aplicação não deve ser interrompida por qualquer exceção HTTP
5. Em caso de sucesso, o resultado deverá estar salvo no arquivo ou diretório cujo caminho foi passado no parâmetro `--output`.
6. Nenhum documento cujo ISSN não está na lista informada como parâmetro deverá ser enviado

#### Algum cenário de contexto que queira dar?
.

### Screenshots
N/A.

#### Quais são tickets relevantes?
.

### Referências
.